### PR TITLE
Include FFmpeg in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /app/standalone-out && \
 FROM node:22-alpine AS runner
 WORKDIR /app
 
-# Install runtime dependencies for FFmpeg extraction, user management, and DB init
+# Install runtime dependencies for FFmpeg, user management, and DB init
 RUN apk add --no-cache \
     tar \
     xz \
@@ -49,6 +49,7 @@ RUN apk add --no-cache \
     su-exec \
     shadow \
     sqlite \
+    ffmpeg \
     && rm -rf /var/cache/apk/*
 
 ENV NODE_ENV=production
@@ -74,7 +75,9 @@ COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 COPY init-db.sql /app/init-db.sql
 
 # Create directories for data and downloads
+# Symlink system FFmpeg so the app finds it at expected location
 RUN mkdir -p /app/prisma/data /app/downloads /app/ffmpeg \
+    && ln -s /usr/bin/ffmpeg /app/ffmpeg/ffmpeg \
     && chown -R nextjs:nodejs /app
 
 # Copy entrypoint script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,10 @@ services:
       - TVDB_API_KEY=${TVDB_API_KEY}  # Required: Your TVDB API key
       - DOWNLOAD_FOLDER_PATH=/downloads
       - DOWNLOAD_FOLDER_PATH_MAPPING=/downloads/completed  # Path mapping for Sonarr/Radarr
-      - DATABASE_URL=file:./prisma/data/mediathekarr.db
+      - DATABASE_URL=file:/app/prisma/data/mediathekarr.db
     volumes:
       - ./data:/app/prisma/data          # Database persistence
       - ./downloads:/app/downloads        # Temporary download folder
-      - ./ffmpeg:/app/ffmpeg              # FFmpeg binary cache
     ports:
       - "127.0.0.1:6767:6767"            # Change left side port as needed
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Install ffmpeg via apk (no more runtime download needed)
- Symlink to expected location /app/ffmpeg/ffmpeg
- Remove ffmpeg volume from docker-compose (not needed anymore)
- Fix DATABASE_URL in docker-compose to use absolute path

## Benefits
- Faster container startup (no FFmpeg download on first run)
- More reliable (no network dependency for FFmpeg)
- Smaller volume requirements

## Test plan
- [ ] Build image locally
- [ ] Verify FFmpeg is available at /app/ffmpeg/ffmpeg
- [ ] Test video conversion functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)