### PR TITLE
Fix GHCR release image tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -164,6 +164,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -178,4 +179,11 @@ jobs:
 
       - name: Inspect image
         run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      - name: Inspect release tags
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ services:
 
 Nach dem Start ist die Web-Oberfläche unter `http://localhost:6767` erreichbar. Beim ersten Start führt der **Setup-Wizard** durch die Konfiguration (API Keys, Pfade, etc.).
 
+Für reproduzierbare Deployments kann statt `latest` auch eine feste Version verwendet werden:
+
+```yaml
+image: ghcr.io/rundfunkarr/rundfunkarr:1.2.1
+```
+
+Der Git-Tag-Alias mit `v`-Präfix ist ebenfalls verfügbar:
+
+```bash
+docker pull ghcr.io/rundfunkarr/rundfunkarr:v1.2.1
+```
+
 ### Starten
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rundfunkarr",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rundfunkarr",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^6.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rundfunkarr",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Rundfunk indexer for Sonarr/Radarr",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the app/package version to 1.2.1 and synchronize the lockfile
- publish the Git tag alias (for example `v1.2.1`) in addition to semver image tags
- verify `latest`, the Git tag alias, and the semver tag after release manifest creation
- document pinned GHCR image tags in the Docker installation section

## Root Cause
The `v1.2.0` tag workflow was cancelled, so GHCR never published `1.2.0` or `v1.2.0`. The existing `latest` tag still points at the older 1.1.0 image.

## Validation
- `npm ci`
- `npm run lint` (passes with an existing warning in `src/services/ruleset-generator.ts`)
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `git diff --check`

## Release Follow-up
After this PR is merged, create and push an annotated `v1.2.1` tag from `main`, then verify:

```bash
docker buildx imagetools inspect ghcr.io/rundfunkarr/rundfunkarr:latest
docker buildx imagetools inspect ghcr.io/rundfunkarr/rundfunkarr:1.2.1
docker buildx imagetools inspect ghcr.io/rundfunkarr/rundfunkarr:v1.2.1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker usage guidance with examples of pinning container images to specific version tags (`:1.2.1` and `:v1.2.1`) for reproducible deployments.

* **Chores**
  * Version bump to 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->