### PR TITLE
Support TVDB project API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ DATABASE_URL="file:./data/rundfunkarr.db"
 DOWNLOAD_FOLDER_PATH="/downloads"
 
 # Show metadata APIs (at least one recommended, both optional)
-# Get TVDB API key: https://thetvdb.com/dashboard/account/apikey (requires subscription)
+# Get TVDB API key: https://thetvdb.com/dashboard/account/apikey
+# Project API keys work without a PIN; subscriber keys can use a PIN in the UI.
 TVDB_API_KEY=""
 # Get TMDB API key: https://www.themoviedb.org/settings/api (free)
 TMDB_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ RundfunkArr bietet eine vollständige Web-Oberfläche mit:
 RundfunkArr sucht Show-Informationen in folgender Reihenfolge:
 
 1. **Lokale Datenbank** (`data/shows.json`) - Kein API Key nötig
-2. **TVDB** - Wenn in den Einstellungen konfiguriert (Project API Key ohne PIN oder Subscriber-Key mit PIN)
+2. **TVDB** - Wenn in den Einstellungen konfiguriert (Project API Key ohne PIN oder Subscriber-Key mit optionalem PIN)
 3. **TMDB** - Wenn in den Einstellungen konfiguriert (kostenlos)
 
 Für Shows die nicht in TVDB/TMDB sind, können Einträge in `data/shows.json` hinzugefügt werden.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ RundfunkArr bietet eine vollständige Web-Oberfläche mit:
 RundfunkArr sucht Show-Informationen in folgender Reihenfolge:
 
 1. **Lokale Datenbank** (`data/shows.json`) - Kein API Key nötig
-2. **TVDB** - Wenn in den Einstellungen konfiguriert (kostenpflichtig)
+2. **TVDB** - Wenn in den Einstellungen konfiguriert (Project API Key ohne PIN oder Subscriber-Key mit PIN)
 3. **TMDB** - Wenn in den Einstellungen konfiguriert (kostenlos)
 
 Für Shows die nicht in TVDB/TMDB sind, können Einträge in `data/shows.json` hinzugefügt werden.

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { clearSettingsCache } from "@/lib/settings";
 import { clearTTLCache } from "@/lib/cache";
+import { isTvdbCredentialSettingKey } from "@/lib/tvdb-auth";
+import { clearTvdbTokenCache } from "@/services/tvdb";
 
 // Default settings
 const DEFAULT_SETTINGS: Record<string, string> = {
@@ -66,21 +68,26 @@ export async function POST(request: NextRequest) {
 
     // Handle single key-value pair
     if (body.key && body.value !== undefined) {
+      const key = String(body.key);
       await prisma.config.upsert({
-        where: { key: body.key },
+        where: { key },
         update: { value: String(body.value) },
-        create: { key: body.key, value: String(body.value) },
+        create: { key, value: String(body.value) },
       });
       clearSettingsCache();
+      if (isTvdbCredentialSettingKey(key)) {
+        await clearTvdbTokenCache();
+      }
       // Clear TTL cache if cache settings changed
-      if (body.key.startsWith("cache.")) {
+      if (key.startsWith("cache.")) {
         clearTTLCache();
       }
-      return NextResponse.json({ success: true, key: body.key });
+      return NextResponse.json({ success: true, key });
     }
 
     // Handle multiple settings
     if (typeof body === "object" && !body.key) {
+      const changedKeys = Object.keys(body);
       const updates = Object.entries(body).map(([key, value]) =>
         prisma.config.upsert({
           where: { key },
@@ -90,11 +97,14 @@ export async function POST(request: NextRequest) {
       );
       await Promise.all(updates);
       clearSettingsCache();
+      if (changedKeys.some(isTvdbCredentialSettingKey)) {
+        await clearTvdbTokenCache();
+      }
       // Clear TTL cache if any cache settings changed
-      if (Object.keys(body).some((key) => key.startsWith("cache."))) {
+      if (changedKeys.some((key) => key.startsWith("cache."))) {
         clearTTLCache();
       }
-      return NextResponse.json({ success: true, updated: Object.keys(body).length });
+      return NextResponse.json({ success: true, updated: changedKeys.length });
     }
 
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
@@ -118,6 +128,9 @@ export async function DELETE(request: NextRequest) {
       where: { key },
     });
     clearSettingsCache();
+    if (isTvdbCredentialSettingKey(key)) {
+      await clearTvdbTokenCache();
+    }
     if (key.startsWith("cache.")) {
       clearTTLCache();
     }
@@ -125,6 +138,9 @@ export async function DELETE(request: NextRequest) {
   } catch {
     // Key might not exist, which is fine
     clearSettingsCache();
+    if (isTvdbCredentialSettingKey(key)) {
+      await clearTvdbTokenCache();
+    }
     if (key.startsWith("cache.")) {
       clearTTLCache();
     }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useSettings } from "@/contexts/settings-context";
+import { buildTvdbLoginPayload } from "@/lib/tvdb-auth";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
@@ -122,7 +123,8 @@ export default function SettingsPage() {
     try {
       const key = getFieldValue("api.tvdb.key");
       const pin = getFieldValue("api.tvdb.pin");
-      if (!key || !pin) {
+      const payload = buildTvdbLoginPayload(key, pin);
+      if (!payload) {
         setApiStatus((prev) => ({ ...prev, tvdb: false }));
         return;
       }
@@ -130,7 +132,7 @@ export default function SettingsPage() {
       const res = await fetch("https://api4.thetvdb.com/v4/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ apikey: key, pin }),
+        body: JSON.stringify(payload),
       });
       setApiStatus((prev) => ({ ...prev, tvdb: res.ok }));
     } catch {
@@ -297,7 +299,8 @@ export default function SettingsPage() {
                 <CardHeader>
                   <CardTitle>TVDB API</CardTitle>
                   <CardDescription>
-                    TheTVDB.com API-Zugangsdaten für Show-Metadaten.{" "}
+                    TheTVDB.com API-Zugangsdaten für Show-Metadaten. Project API Keys funktionieren
+                    ohne PIN; Subscriber-Keys können weiterhin eine PIN verwenden.{" "}
                     <a
                       href="https://thetvdb.com/api-information"
                       target="_blank"
@@ -319,11 +322,11 @@ export default function SettingsPage() {
                     />
                   </div>
                   <div>
-                    <label className="text-sm font-medium">PIN</label>
+                    <label className="text-sm font-medium">PIN (optional)</label>
                     <Input
                       value={getFieldValue("api.tvdb.pin")}
                       onChange={(e) => setFieldValue("api.tvdb.pin", e.target.value)}
-                      placeholder="TVDB PIN"
+                      placeholder="TVDB PIN (optional)"
                       className="mt-1"
                     />
                   </div>

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSettings } from "@/contexts/settings-context";
+import { buildTvdbLoginPayload } from "@/lib/tvdb-auth";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
@@ -74,12 +75,13 @@ export default function SetupPage() {
     setIsValidating(true);
 
     // Validate TVDB
-    if (tvdbKey && tvdbPin) {
+    const tvdbPayload = buildTvdbLoginPayload(tvdbKey, tvdbPin);
+    if (tvdbPayload) {
       try {
         const res = await fetch("https://api4.thetvdb.com/v4/login", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ apikey: tvdbKey, pin: tvdbPin }),
+          body: JSON.stringify(tvdbPayload),
         });
         setTvdbValid(res.ok);
       } catch {
@@ -261,7 +263,8 @@ export default function SetupPage() {
                 <CardHeader className="pb-3">
                   <CardTitle className="text-base">TheTVDB</CardTitle>
                   <CardDescription>
-                    Für TV-Serien Metadaten.{" "}
+                    Für TV-Serien-Metadaten. Project API Keys funktionieren ohne PIN;
+                    Subscriber-Keys können weiterhin eine PIN verwenden.{" "}
                     <a
                       href="https://thetvdb.com/api-information"
                       target="_blank"
@@ -281,7 +284,7 @@ export default function SetupPage() {
                   <Input
                     value={tvdbPin}
                     onChange={(e) => setValue("api.tvdb.pin", e.target.value)}
-                    placeholder="PIN"
+                    placeholder="PIN (optional)"
                   />
                   {tvdbValid !== null && (
                     <Badge variant={tvdbValid ? "default" : "destructive"}>

--- a/src/lib/tvdb-auth.test.ts
+++ b/src/lib/tvdb-auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildTvdbLoginPayload, isTvdbCredentialSettingKey } from "./tvdb-auth";
+
+describe("buildTvdbLoginPayload", () => {
+  it("builds a payload for project API keys without a PIN", () => {
+    expect(buildTvdbLoginPayload("project-api-key")).toEqual({ apikey: "project-api-key" });
+  });
+
+  it("includes the PIN when one is provided", () => {
+    expect(buildTvdbLoginPayload("subscriber-api-key", "1234")).toEqual({
+      apikey: "subscriber-api-key",
+      pin: "1234",
+    });
+  });
+
+  it("omits blank or whitespace-only PIN values", () => {
+    expect(buildTvdbLoginPayload("project-api-key", "   ")).toEqual({
+      apikey: "project-api-key",
+    });
+  });
+
+  it("trims pasted credentials", () => {
+    expect(buildTvdbLoginPayload("  project-api-key  ", "  1234  ")).toEqual({
+      apikey: "project-api-key",
+      pin: "1234",
+    });
+  });
+
+  it("returns null when no API key is provided", () => {
+    expect(buildTvdbLoginPayload("   ", "1234")).toBeNull();
+  });
+});
+
+describe("isTvdbCredentialSettingKey", () => {
+  it("matches the TVDB credential settings", () => {
+    expect(isTvdbCredentialSettingKey("api.tvdb.key")).toBe(true);
+    expect(isTvdbCredentialSettingKey("api.tvdb.pin")).toBe(true);
+  });
+
+  it("does not match unrelated settings", () => {
+    expect(isTvdbCredentialSettingKey("api.tmdb.key")).toBe(false);
+  });
+});

--- a/src/lib/tvdb-auth.ts
+++ b/src/lib/tvdb-auth.ts
@@ -1,0 +1,29 @@
+export interface TvdbLoginPayload {
+  apikey: string;
+  pin?: string;
+}
+
+export const TVDB_CREDENTIAL_SETTING_KEYS = ["api.tvdb.key", "api.tvdb.pin"] as const;
+
+const TVDB_CREDENTIAL_SETTING_KEY_SET = new Set<string>(TVDB_CREDENTIAL_SETTING_KEYS);
+
+export function isTvdbCredentialSettingKey(key: string): boolean {
+  return TVDB_CREDENTIAL_SETTING_KEY_SET.has(key);
+}
+
+export function buildTvdbLoginPayload(
+  apiKey: string | null | undefined,
+  pin?: string | null
+): TvdbLoginPayload | null {
+  const trimmedApiKey = apiKey?.trim();
+  if (!trimmedApiKey) {
+    return null;
+  }
+
+  const trimmedPin = pin?.trim();
+  if (!trimmedPin) {
+    return { apikey: trimmedApiKey };
+  }
+
+  return { apikey: trimmedApiKey, pin: trimmedPin };
+}

--- a/src/services/tvdb.ts
+++ b/src/services/tvdb.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db";
 import { tvdbCache } from "@/lib/cache";
 import { fetchWithRetry } from "@/lib/fetch-retry";
 import { getSettings } from "@/lib/settings";
+import { buildTvdbLoginPayload } from "@/lib/tvdb-auth";
 import type { TvdbData, TvdbEpisode, TvdbAlias } from "@/types";
 
 const TVDB_API_URL = "https://api4.thetvdb.com/v4";
@@ -9,6 +10,18 @@ const TVDB_API_URL = "https://api4.thetvdb.com/v4";
 // Token management
 let cachedToken: string | null = null;
 let tokenExpiry: Date | null = null;
+
+export function clearTvdbTokenMemoryCache(): void {
+  cachedToken = null;
+  tokenExpiry = null;
+}
+
+export async function clearTvdbTokenCache(): Promise<void> {
+  clearTvdbTokenMemoryCache();
+  await prisma.config.deleteMany({
+    where: { key: { in: ["tvdb_token", "tvdb_token_expiry"] } },
+  });
+}
 
 async function getToken(): Promise<string | null> {
   // Check if we have a valid cached token
@@ -42,8 +55,9 @@ async function refreshToken(): Promise<string | null> {
   const settings = await getSettings(["api.tvdb.key", "api.tvdb.pin"]);
   const apiKey = settings["api.tvdb.key"];
   const pin = settings["api.tvdb.pin"];
+  const payload = buildTvdbLoginPayload(apiKey, pin);
 
-  if (!apiKey) {
+  if (!payload) {
     console.error("TVDB API key not configured in settings");
     return null;
   }
@@ -52,7 +66,7 @@ async function refreshToken(): Promise<string | null> {
     const response = await fetchWithRetry(`${TVDB_API_URL}/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ apikey: apiKey, pin: pin || undefined }),
+      body: JSON.stringify(payload),
     });
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
- Allow TVDB Project API Keys to authenticate without a PIN while preserving subscriber-key PIN support.
- Share TVDB login payload normalization across server auth, Settings validation, and Setup validation.
- Clear cached TVDB auth tokens when TVDB credentials change, and update copy/docs to mark the PIN as optional.

Fixes #21

## Test Plan
- npm test
- npm run typecheck
- npm run lint (passes with an existing warning in src/services/ruleset-generator.ts)
- npm run format:check
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment and README documentation to clarify TVDB API key configuration and optional PIN usage

* **UI/UX Improvements**
  * Clarified TVDB PIN field as optional throughout settings and setup flows with improved labels and placeholder text

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rundfunkarr/rundfunkarr/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->