### PR TITLE
Add daily nightly Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "17 3 * * *"
 
 env:
   REGISTRY: ghcr.io
@@ -80,7 +82,7 @@ jobs:
 
   build-arm64:
     runs-on: ubuntu-24.04-arm
-    if: ${{ github.ref_type == 'tag' }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'schedule' }}
     permissions:
       contents: read
       packages: write
@@ -162,9 +164,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }}
             type=ref,event=pr
             type=ref,event=tag
+            type=schedule,pattern=nightly
+            type=schedule,pattern=nightly-{{date 'YYYYMMDD'}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ services:
 
 Nach dem Start ist die Web-Oberfläche unter `http://localhost:6767` erreichbar. Beim ersten Start führt der **Setup-Wizard** durch die Konfiguration (API Keys, Pfade, etc.).
 
+Für Tests mit dem aktuellen `main`-Stand werden täglich Nightly-Images für `linux/amd64` und `linux/arm64` gebaut. `nightly` zeigt immer auf den neuesten Daily-Build; datierte Tags wie
+`nightly-20260517` bleiben als konkreter Build erhalten:
+
+```yaml
+image: ghcr.io/rundfunkarr/rundfunkarr:nightly
+```
+
 Für reproduzierbare Deployments kann statt `latest` auch eine feste Version verwendet werden:
 
 ```yaml


### PR DESCRIPTION
## Summary

- Add a daily scheduled Docker workflow run at 03:17 UTC.
- Publish nightly multi-arch GHCR tags for `linux/amd64` and `linux/arm64`.
- Document the `nightly` Docker image tag in the README.

## Details

The scheduled build publishes `nightly` and dated `nightly-YYYYMMDD` tags while keeping release tag behavior unchanged. Scheduled runs do not also publish the `main` branch tag.

## Validation

- `npx prettier --check .github/workflows/docker-build.yml`
- `git diff --check --cached`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify daily nightly container image builds and their tagging strategy for both `linux/amd64` and `linux/arm64` architectures.

* **Chores**
  * Refined CI/CD workflow to optimize tag-based and scheduled container builds with improved metadata tagging for nightly releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rundfunkarr/rundfunkarr/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->