### PR TITLE
fix: include generic Newznab results for titles without a ruleset

### DIFF
--- a/src/services/mediathek.test.ts
+++ b/src/services/mediathek.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ApiResultItem } from "@/types";
+
+// Keep the unit hermetic: no DB, no network, no ruleset store.
+vi.mock("@/lib/settings", () => ({
+  // null -> defaults kick in: quality "all", minDuration 300s, fuzzy/0.7
+  getSetting: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("@/lib/cache", () => ({
+  mediathekCache: { get: vi.fn().mockReturnValue(undefined), set: vi.fn() },
+}));
+vi.mock("@/lib/fetch-retry", () => ({ fetchWithRetry: vi.fn() }));
+// No rulesets -> every API result becomes an "unmatched" item.
+vi.mock("./rulesets", () => ({
+  ensureRulesetsLoaded: vi.fn().mockResolvedValue(undefined),
+  getRulesetsForTopic: vi.fn().mockReturnValue([]),
+  getRulesetsForTopicAndTvdbId: vi.fn().mockReturnValue([]),
+  getAllTopics: vi.fn().mockReturnValue([]),
+  getOrGenerateRulesetForShow: vi.fn().mockResolvedValue(null),
+}));
+
+import { fetchSearchResultsByString } from "./mediathek";
+import { fetchWithRetry } from "@/lib/fetch-retry";
+
+const mockedFetch = vi.mocked(fetchWithRetry);
+
+function makeItem(overrides: Partial<ApiResultItem> = {}): ApiResultItem {
+  return {
+    channel: "ARD",
+    topic: "Irgendeine Sendung",
+    title: "Irgendeine Sendung (S01/E03)",
+    description: "",
+    filmlisteTimestamp: 1_700_000_000,
+    duration: 3600,
+    size: 1_000_000_000,
+    url_website: "https://example.com/show",
+    url_video: "https://example.com/show_720.mp4",
+    url_video_low: "https://example.com/show_480.mp4",
+    url_video_hd: "https://example.com/show_1080.mp4",
+    ...overrides,
+  };
+}
+
+function mockApi(results: ApiResultItem[]): void {
+  mockedFetch.mockResolvedValue({
+    ok: true,
+    text: async () => JSON.stringify({ result: { results } }),
+  } as Response);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchSearchResultsByString – generic result gating", () => {
+  it("emits NO generic results for a season-only query (no q)", async () => {
+    // Regression for tvsearch&season=01 without q: without the gate this
+    // returned generic items for every unrelated show whose title contains "S01".
+    mockApi([
+      makeItem({ topic: "Show A", title: "Show A (S01/E01)" }),
+      makeItem({ topic: "Show B", title: "Show B (S01/E02)" }),
+    ]);
+
+    const xml = await fetchSearchResultsByString(null, "01", 100, 0);
+
+    expect(xml).toContain('total="0"');
+    expect(xml).not.toContain("<item>");
+  });
+
+  it("DOES emit generic results for an actual text query (q set)", async () => {
+    mockApi([makeItem({ topic: "Markus Lanz", title: "Markus Lanz (S2026/E70)" })]);
+
+    const xml = await fetchSearchResultsByString("Markus Lanz", null, 100, 0);
+
+    expect(xml).not.toContain('total="0"');
+    expect(xml).toContain("<item>");
+  });
+
+  it("treats a whitespace-only q like an empty query (no generic results)", async () => {
+    mockApi([makeItem({ topic: "Show C", title: "Show C (S01/E04)" })]);
+
+    const xml = await fetchSearchResultsByString("   ", "01", 100, 0);
+
+    expect(xml).toContain('total="0"');
+    expect(xml).not.toContain("<item>");
+  });
+});

--- a/src/services/mediathek.ts
+++ b/src/services/mediathek.ts
@@ -12,6 +12,7 @@ import {
 import {
   generateRssItems,
   generateMovieRssItems,
+  generateGenericRssItems,
   convertItemsToRss,
   serializeRss,
   getEmptyRssResult,
@@ -611,6 +612,8 @@ async function applyRulesetFilters(
 
       if (matchInfo) {
         matchedEpisodes.push(matchInfo);
+        const idx = unmatchedItems.indexOf(item);
+        if (idx > -1) unmatchedItems.splice(idx, 1);
         break;
       } else {
         const idx = unmatchedItems.indexOf(item);
@@ -829,11 +832,18 @@ export async function fetchSearchResultsByString(
     return serializeRss(getEmptyRssResult());
   }
 
-  const { matchedEpisodes } = await applyRulesetFilters(results);
+  const { matchedEpisodes, unmatchedItems } = await applyRulesetFilters(results);
   const newznabItems: NewznabItem[] = matchedEpisodes.flatMap((info) =>
     generateRssItems(info, quality)
   );
-  const response = convertItemsToRss(newznabItems, limit, offset);
+
+  // Include unmatched items (no ruleset) as generic results so they still appear in search
+  const genericItems: NewznabItem[] = unmatchedItems.flatMap((item) =>
+    generateGenericRssItems(item, quality)
+  );
+
+  const allItems = [...newznabItems, ...genericItems];
+  const response = convertItemsToRss(allItems, limit, offset);
 
   mediathekCache.set(cacheKey, { response });
   return response;

--- a/src/services/mediathek.ts
+++ b/src/services/mediathek.ts
@@ -787,17 +787,20 @@ export async function fetchSearchResultsByString(
   limit: number,
   offset: number
 ): Promise<string> {
+  // Normalize once: a whitespace-only q is treated as no query everywhere
+  // (API query, cache keys, and generic gating) so behavior stays consistent.
+  const trimmedQ = q?.trim() || null;
   const quality = await getQualityPreference();
   const minDuration = await getMinDuration();
   const matchingSettings = await getMatchingSettings();
-  const cacheKey = `q_${q ?? "null"}_${season ?? "null"}_${limit}_${offset}_${quality}_${minDuration}_${matchingSettings.threshold}`;
+  const cacheKey = `q_${trimmedQ ?? "null"}_${season ?? "null"}_${limit}_${offset}_${quality}_${minDuration}_${matchingSettings.threshold}`;
 
   const cached = mediathekCache.get(cacheKey);
   if (cached) {
     return (cached as { response: string }).response;
   }
 
-  const apiCacheKey = `mediathekapi_${q ?? "null"}_${season ?? "null"}`;
+  const apiCacheKey = `mediathekapi_${trimmedQ ?? "null"}_${season ?? "null"}`;
   let apiResponse: string;
   const cachedApi = mediathekCache.get(apiCacheKey);
 
@@ -806,8 +809,8 @@ export async function fetchSearchResultsByString(
   } else {
     const queries: Array<{ fields: string[]; query: string }> = [];
 
-    if (q) {
-      queries.push({ fields: QUERY_FIELDS, query: q });
+    if (trimmedQ) {
+      queries.push({ fields: QUERY_FIELDS, query: trimmedQ });
     }
 
     if (season) {
@@ -841,7 +844,7 @@ export async function fetchSearchResultsByString(
   // A season-only query (e.g. tvsearch&season=01 with no q) would otherwise emit
   // every title that merely contains "S01" across unrelated shows. Gate on a
   // non-empty q to keep the previous (matched-only) behavior for those queries.
-  const hasTextQuery = !!q?.trim();
+  const hasTextQuery = !!trimmedQ;
   const genericItems: NewznabItem[] = hasTextQuery
     ? unmatchedItems.flatMap((item) => generateGenericRssItems(item, quality))
     : [];

--- a/src/services/mediathek.ts
+++ b/src/services/mediathek.ts
@@ -837,10 +837,14 @@ export async function fetchSearchResultsByString(
     generateRssItems(info, quality)
   );
 
-  // Include unmatched items (no ruleset) as generic results so they still appear in search
-  const genericItems: NewznabItem[] = unmatchedItems.flatMap((item) =>
-    generateGenericRssItems(item, quality)
-  );
+  // Generic (no-ruleset) results are only meaningful for an actual text search.
+  // A season-only query (e.g. tvsearch&season=01 with no q) would otherwise emit
+  // every title that merely contains "S01" across unrelated shows. Gate on a
+  // non-empty q to keep the previous (matched-only) behavior for those queries.
+  const hasTextQuery = !!q?.trim();
+  const genericItems: NewznabItem[] = hasTextQuery
+    ? unmatchedItems.flatMap((item) => generateGenericRssItems(item, quality))
+    : [];
 
   const allItems = [...newznabItems, ...genericItems];
   const response = convertItemsToRss(allItems, limit, offset);

--- a/src/services/newznab.test.ts
+++ b/src/services/newznab.test.ts
@@ -6,8 +6,9 @@ import {
   convertItemsToRss,
   generateFakeNzb,
   getCapabilitiesXml,
+  generateGenericRssItems,
 } from "./newznab";
-import type { NewznabItem } from "@/types";
+import type { NewznabItem, ApiResultItem } from "@/types";
 
 describe("generateAttributes", () => {
   it("should generate category attributes", () => {
@@ -196,5 +197,105 @@ describe("getCapabilitiesXml", () => {
 
     expect(xml).toContain("<registration");
     expect(xml).toContain('available="no"');
+  });
+});
+
+describe("generateGenericRssItems", () => {
+  const baseItem: ApiResultItem = {
+    channel: "ARD",
+    topic: "Beispielserie",
+    title: "Folge 5: Der Anfang",
+    description: "An example description",
+    filmlisteTimestamp: 1700000000,
+    duration: 2700,
+    size: 1_000_000_000,
+    url_website: "https://example.com/video",
+    url_video: "https://example.com/video_720.mp4",
+    url_video_low: "https://example.com/video_480.mp4",
+    url_video_hd: "https://example.com/video_1080.mp4",
+  };
+
+  it("emits one item per available quality with preference all", () => {
+    const items = generateGenericRssItems(baseItem, "all");
+
+    expect(items).toHaveLength(3);
+    const guids = items.map((i) => i.guid.value);
+    expect(guids.some((g) => g.endsWith("#1080p"))).toBe(true);
+    expect(guids.some((g) => g.endsWith("#720p"))).toBe(true);
+    expect(guids.some((g) => g.endsWith("#480p"))).toBe(true);
+  });
+
+  it("picks only the highest quality with preference best", () => {
+    const items = generateGenericRssItems(baseItem, "best");
+
+    expect(items).toHaveLength(1);
+    expect(items[0].guid.value).toBe("https://example.com/video#1080p");
+  });
+
+  it("parses Folge N titles into season/episode attributes", () => {
+    const items = generateGenericRssItems(baseItem, "best");
+    const attrs = items[0].attributes;
+
+    expect(attrs.find((a) => a.name === "season")).toEqual({ name: "season", value: "01" });
+    expect(attrs.find((a) => a.name === "episode")).toEqual({ name: "episode", value: "05" });
+  });
+
+  it("parses explicit S<season>/E<episode> titles", () => {
+    const items = generateGenericRssItems({ ...baseItem, title: "Tolle Folge (S02/E03)" }, "best");
+    const attrs = items[0].attributes;
+
+    expect(attrs.find((a) => a.name === "season")).toEqual({ name: "season", value: "02" });
+    expect(attrs.find((a) => a.name === "episode")).toEqual({ name: "episode", value: "03" });
+  });
+
+  it("still emits a generic item when no episode info is present", () => {
+    const items = generateGenericRssItems(
+      { ...baseItem, title: "Reportage without a number" },
+      "best"
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0].attributes.find((a) => a.name === "episode")).toBeUndefined();
+    expect(items[0].attributes.some((a) => a.name === "category")).toBe(true);
+  });
+});
+
+describe("generateGenericRssItems - edge cases", () => {
+  const base: ApiResultItem = {
+    channel: "ARD",
+    topic: "Beispielserie",
+    title: "",
+    description: "An example description",
+    filmlisteTimestamp: 1700000000,
+    duration: 2700,
+    size: 1_000_000_000,
+    url_website: "https://example.com/video",
+    url_video: "https://example.com/video_720.mp4",
+    url_video_low: "https://example.com/video_480.mp4",
+    url_video_hd: "https://example.com/video_1080.mp4",
+  };
+
+  it("keeps episode 0 and does not let later patterns overwrite it", () => {
+    const items = generateGenericRssItems({ ...base, title: "Folge 0 (2/6)" }, "best");
+    const attrs = items[0].attributes;
+
+    expect(attrs.find((a) => a.name === "episode")).toEqual({ name: "episode", value: "00" });
+    expect(attrs.find((a) => a.name === "season")).toEqual({ name: "season", value: "01" });
+  });
+
+  it("parses Staffel N Folge N", () => {
+    const items = generateGenericRssItems({ ...base, title: "Staffel 2 Folge 3" }, "best");
+    const attrs = items[0].attributes;
+
+    expect(attrs.find((a) => a.name === "season")).toEqual({ name: "season", value: "02" });
+    expect(attrs.find((a) => a.name === "episode")).toEqual({ name: "episode", value: "03" });
+  });
+
+  it("emits only the available quality variant", () => {
+    const only720 = { ...base, title: "Some show", url_video_hd: "", url_video_low: "" };
+    const items = generateGenericRssItems(only720, "all");
+
+    expect(items).toHaveLength(1);
+    expect(items[0].guid.value).toBe("https://example.com/video#720p");
   });
 });

--- a/src/services/newznab.ts
+++ b/src/services/newznab.ts
@@ -500,6 +500,233 @@ export function generateMovieRssItems(
   return items;
 }
 
+/**
+ * Generate RSS items for API results that don't match any ruleset.
+ * Uses topic + title as the release name so they still appear in search results.
+ */
+export function generateGenericRssItems(
+  item: ApiResultItem,
+  qualityPreference: QualityPreference = "all"
+): NewznabItem[] {
+  const items: NewznabItem[] = [];
+  const baseCategories = ["5000"];
+
+  const has1080p = !!item.url_video_hd;
+  const has720p = !!item.url_video;
+  const has480p = !!item.url_video_low;
+
+  let include1080p = false;
+  let include720p = false;
+  let include480p = false;
+
+  switch (qualityPreference) {
+    case "all":
+      include1080p = has1080p;
+      include720p = has720p;
+      include480p = has480p;
+      break;
+    case "best":
+      if (has1080p) {
+        include1080p = true;
+      } else if (has720p) {
+        include720p = true;
+      } else if (has480p) {
+        include480p = true;
+      }
+      break;
+    case "1080p":
+      include1080p = has1080p;
+      break;
+    case "720p":
+      include720p = has720p;
+      break;
+    case "480p":
+      include480p = has480p;
+      break;
+  }
+
+  if (include1080p) {
+    items.push(
+      createGenericRssItem(
+        item,
+        "1080p",
+        1.6,
+        "TV > HD",
+        [...baseCategories, "5040"],
+        item.url_video_hd
+      )
+    );
+  }
+
+  if (include720p) {
+    items.push(
+      createGenericRssItem(
+        item,
+        "720p",
+        1.0,
+        "TV > HD",
+        [...baseCategories, "5040"],
+        item.url_video
+      )
+    );
+  }
+
+  if (include480p) {
+    items.push(
+      createGenericRssItem(
+        item,
+        "480p",
+        0.4,
+        "TV > SD",
+        [...baseCategories, "5030"],
+        item.url_video_low
+      )
+    );
+  }
+
+  return items;
+}
+
+/**
+ * Parse season and episode numbers from Mediathek titles.
+ * Common patterns:
+ *   (S01/E05), (S2026/E02)  — standard ARD/ZDF format
+ *   (4/6)                    — episode/total format (no season info)
+ *   Folge 5, Folge 5:        — episode-only with optional colon
+ *   Staffel 2 Folge 3        — explicit season + episode
+ */
+function parseEpisodeFromTitle(title: string): {
+  season: number | null;
+  episode: number | null;
+  episodeName: string;
+} {
+  let season: number | null = null;
+  let episode: number | null = null;
+  let episodeName = title;
+
+  // Pattern 1: (S01/E05) or S01/E05
+  const sPattern = title.match(/\(?S(\d+)\/E(\d+)\)?/i);
+  if (sPattern) {
+    season = parseInt(sPattern[1], 10);
+    episode = parseInt(sPattern[2], 10);
+    episodeName = title.replace(sPattern[0], "").trim();
+  }
+
+  // Pattern 2: Staffel N Folge N
+  if (episode === null) {
+    const staffelPattern = title.match(/Staffel\s+(\d+)\s+Folge\s+(\d+)/i);
+    if (staffelPattern) {
+      season = parseInt(staffelPattern[1], 10);
+      episode = parseInt(staffelPattern[2], 10);
+      episodeName = title.replace(staffelPattern[0], "").trim();
+    }
+  }
+
+  // Pattern 3: Folge N (with optional episode name after colon)
+  if (episode === null) {
+    const folgePattern = title.match(/Folge\s+(\d+)(?:\s*:\s*(.+?))?(?:\s*\(|$)/i);
+    if (folgePattern) {
+      episode = parseInt(folgePattern[1], 10);
+      if (folgePattern[2]) {
+        episodeName = folgePattern[2].trim();
+      } else {
+        episodeName = title.replace(folgePattern[0], "").trim();
+      }
+    }
+  }
+
+  // Pattern 4: (N/N) — episode/total, only if no season found yet
+  if (episode === null) {
+    const fracPattern = title.match(/\((\d+)\/(\d+)\)/);
+    if (fracPattern) {
+      episode = parseInt(fracPattern[1], 10);
+      episodeName = title.replace(fracPattern[0], "").trim();
+    }
+  }
+
+  // Clean up episode name: remove trailing "(Audiodeskription)", "(mit Untertitel)", etc.
+  episodeName = episodeName
+    .replace(/\(Audiodeskription\)/gi, "")
+    .replace(/\(mit Untertitel\)/gi, "")
+    .replace(/\(Originalversion\)/gi, "")
+    .replace(/\s*\|\s*/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  // Remove leading/trailing punctuation artifacts
+  episodeName = episodeName.replace(/^[:\-–\s]+|[:\-–\s]+$/g, "").trim();
+
+  return { season, episode, episodeName };
+}
+
+function createGenericRssItem(
+  item: ApiResultItem,
+  quality: string,
+  sizeMultiplier: number,
+  category: string,
+  categoryValues: string[],
+  url: string
+): NewznabItem {
+  const adjustedSize = Math.floor(item.size * sizeMultiplier);
+
+  const parsed = parseEpisodeFromTitle(item.title);
+  let rawTitle: string;
+
+  if (parsed.episode !== null) {
+    const seasonNum = parsed.season ?? 1;
+    const paddedSeason = seasonNum.toString().padStart(2, "0");
+    const paddedEpisode = parsed.episode.toString().padStart(2, "0");
+    const epName = parsed.episodeName || item.title;
+    rawTitle = `${item.topic}.S${paddedSeason}E${paddedEpisode}.${epName}.GERMAN.${quality}.WEB.h264-MEDiATHEK`;
+  } else {
+    rawTitle = `${item.topic}.${item.title}.GERMAN.${quality}.WEB.h264-MEDiATHEK`;
+  }
+
+  const formattedTitle = formatTitle(rawTitle);
+
+  const encodedTitle = Buffer.from(formattedTitle).toString("base64");
+  const encodedUrl = Buffer.from(url).toString("base64");
+
+  const fakeDownloadUrl = `/api/newznab/fake_nzb_download?encodedUrl=${encodedUrl}&encodedTitle=${encodedTitle}`;
+
+  const attributes: NewznabAttribute[] = categoryValues.map((v) => ({
+    name: "category",
+    value: v,
+  }));
+
+  // Add season/episode attributes if parsed
+  if (parsed.episode !== null) {
+    const seasonNum = parsed.season ?? 1;
+    attributes.push({
+      name: "season",
+      value: seasonNum.toString().padStart(2, "0"),
+    });
+    attributes.push({
+      name: "episode",
+      value: parsed.episode.toString().padStart(2, "0"),
+    });
+  }
+
+  return {
+    title: formattedTitle,
+    guid: {
+      isPermaLink: true,
+      value: `${item.url_website}#${quality}`,
+    },
+    link: url,
+    comments: item.url_website,
+    pubDate: new Date(item.filmlisteTimestamp * 1000).toUTCString(),
+    category: category,
+    description: item.description,
+    enclosure: {
+      url: fakeDownloadUrl,
+      length: adjustedSize,
+      type: "application/x-nzb",
+    },
+    attributes,
+  };
+}
+
 // Generate fake NZB file content
 export function generateFakeNzb(url: string, title: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/services/newznab.ts
+++ b/src/services/newznab.ts
@@ -676,8 +676,11 @@ function createGenericRssItem(
     const seasonNum = parsed.season ?? 1;
     const paddedSeason = seasonNum.toString().padStart(2, "0");
     const paddedEpisode = parsed.episode.toString().padStart(2, "0");
-    const epName = parsed.episodeName || item.title;
-    rawTitle = `${item.topic}.S${paddedSeason}E${paddedEpisode}.${epName}.GERMAN.${quality}.WEB.h264-MEDiATHEK`;
+    // Omit the episode-name segment when the pattern consumed the whole title
+    // (e.g. "Staffel 2 Folge 3"), otherwise it duplicates the SxxExx info.
+    rawTitle = parsed.episodeName
+      ? `${item.topic}.S${paddedSeason}E${paddedEpisode}.${parsed.episodeName}.GERMAN.${quality}.WEB.h264-MEDiATHEK`
+      : `${item.topic}.S${paddedSeason}E${paddedEpisode}.GERMAN.${quality}.WEB.h264-MEDiATHEK`;
   } else {
     rawTitle = `${item.topic}.${item.title}.GERMAN.${quality}.WEB.h264-MEDiATHEK`;
   }


### PR DESCRIPTION
## Description

A string/text search via the Newznab endpoint (`t=search` / `t=tvsearch`, as issued by Sonarr/Radarr when adding a series or movie) currently returns results **only** for titles that have a matching ruleset. For every other title the endpoint returns an empty RSS feed — even when the Mediathek API has plenty of hits. As a result, most public-broadcaster content cannot be found or grabbed through search in Sonarr/Radarr.

`fetchSearchResultsByString` now also emits API results that match no ruleset as **generic** Newznab items (1080p/720p/480p variants, mirroring the matched path). Common German episode patterns are parsed from the title into `season`/`episode` attributes:

- `(S01/E05)`, `S2026/E02`
- `Staffel 2 Folge 3`
- `Folge 5` / `Folge 5: <title>`
- `(4/6)` (episode/total)

A small related fix in `applyRulesetFilters`: a matched item is now removed from the unmatched list, so it can no longer appear twice (once matched, once generic).

## Type of change

- [x] Bug fix (no breaking changes; matched results are unchanged)

## Before / after

Live example against the real Mediathek API, query `Markus Lanz` (no ruleset), `t=tvsearch`:

**Before** (v1.2.1):

```xml
<newznab:response offset="0" total="0"/>
```

**After** (this PR) — `total="906"`, e.g.:

```xml
<item>
  <title>Markus.Lanz.S2026E70.Markus.Lanz.vom.11.Juni.2026.GERMAN.1080p.WEB.h264-MEDiATHEK</title>
  <guid isPermaLink="true">https://www.zdf.de/video/talk/markus-lanz-114/markus-lanz-vom-11-juni-2026-100#1080p</guid>
  <category>TV &gt; HD</category>
  <newznab:attr name="category" value="5000"/>
  <newznab:attr name="category" value="5040"/>
  <newznab:attr name="season" value="2026"/>
  <newznab:attr name="episode" value="70"/>
</item>
```

Same effect for `maybrit illner` (0 → 210) and `Panorama` (0 → 1840).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run typecheck`
- [x] `npm run test` (incl. new tests for `generateGenericRssItems`)
- [x] `npm run build`
- [x] Tested locally (running in production since April 2026)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unmatched search results can now generate generic RSS items for feeds.
  * Automatic season/episode extraction from various title patterns.
  * Multiple quality variants (1080p/720p/480p) with selectable preference.

* **Bug Fixes**
  * Matched items are no longer duplicated as generic/unmatched results.
  * Season-only or empty-text queries continue to return matched-only results (no generics).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->