### PR TITLE
Fix missing TopicCategory table in SQLite bootstrap

### DIFF
--- a/init-db.sql
+++ b/init-db.sql
@@ -43,6 +43,8 @@ CREATE TABLE IF NOT EXISTS Download (
     completedAt DATETIME
 );
 
+CREATE INDEX IF NOT EXISTS Download_status_idx ON Download(status);
+
 CREATE TABLE IF NOT EXISTS Config (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
@@ -64,6 +66,16 @@ CREATE TABLE IF NOT EXISTS GeneratedRuleset (
 );
 
 CREATE INDEX IF NOT EXISTS GeneratedRuleset_tvdbId_idx ON GeneratedRuleset(tvdbId);
+
+CREATE TABLE IF NOT EXISTS TopicCategory (
+    id TEXT PRIMARY KEY,
+    topic TEXT NOT NULL UNIQUE,
+    category TEXT NOT NULL,
+    tmdbId INTEGER,
+    cachedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS TopicCategory_topic_idx ON TopicCategory(topic);
 
 -- Prisma migrations table (for compatibility)
 CREATE TABLE IF NOT EXISTS _prisma_migrations (

--- a/init-db.sql
+++ b/init-db.sql
@@ -68,11 +68,11 @@ CREATE TABLE IF NOT EXISTS GeneratedRuleset (
 CREATE INDEX IF NOT EXISTS GeneratedRuleset_tvdbId_idx ON GeneratedRuleset(tvdbId);
 
 CREATE TABLE IF NOT EXISTS TopicCategory (
-    id TEXT PRIMARY KEY,
+    id TEXT NOT NULL PRIMARY KEY,
     topic TEXT NOT NULL UNIQUE,
     category TEXT NOT NULL,
     tmdbId INTEGER,
-    cachedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    cachedAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS TopicCategory_topic_idx ON TopicCategory(topic);

--- a/prisma/migrations/20260708000000_add_topic_category/migration.sql
+++ b/prisma/migrations/20260708000000_add_topic_category/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "TopicCategory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "topic" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "tmdbId" INTEGER,
+    "cachedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TopicCategory_topic_key" ON "TopicCategory"("topic");
+
+-- CreateIndex
+CREATE INDEX "TopicCategory_topic_idx" ON "TopicCategory"("topic");
+
+-- CreateIndex
+CREATE INDEX "Download_status_idx" ON "Download"("status");

--- a/src/lib/db-schema.test.ts
+++ b/src/lib/db-schema.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+function getPrismaModelNames(schema: string): string[] {
+  return Array.from(schema.matchAll(/^model\s+(\w+)\s+\{/gm), (match) => match[1]);
+}
+
+function getInitDbTableNames(sql: string): Set<string> {
+  return new Set(
+    Array.from(
+      sql.matchAll(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["`]?(\w+)["`]?\s*\(/gim),
+      (match) => match[1]
+    )
+  );
+}
+
+describe("database bootstrap schema", () => {
+  it("creates every Prisma model table in init-db.sql", () => {
+    const root = process.cwd();
+    const schema = readFileSync(path.join(root, "prisma", "schema.prisma"), "utf-8");
+    const initDbSql = readFileSync(path.join(root, "init-db.sql"), "utf-8");
+
+    const initDbTables = getInitDbTableNames(initDbSql);
+    const missingTables = getPrismaModelNames(schema).filter((model) => !initDbTables.has(model));
+
+    expect(missingTables).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add the missing `TopicCategory` table and topic index to `init-db.sql` so Docker startup upgrades existing SQLite volumes
- add a Prisma migration for `TopicCategory` for non-Docker migration users
- align the existing `Download_status_idx` SQL bootstrap/migration state with the current Prisma schema
- add a Vitest regression test that catches Prisma models missing from `init-db.sql`

## Root Cause
Issue #25 is schema drift. The application queries `prisma.topicCategory`, but the Docker image initializes and upgrades `/app/prisma/data/rundfunkarr.db` by replaying `init-db.sql`, and that SQL did not create the `TopicCategory` table. Users should not need to run `npx prisma` inside the container; doing so currently downloads Prisma 7 and hits the Prisma 7 datasource-url config change instead of fixing the image-managed database path.

Fixes #25.

## Validation
- temp SQLite DB initialized from `init-db.sql` plus `prisma.topicCategory.findMany()` returns `topicCategory rows 0`
- `DATABASE_URL=file:./prisma/data/rundfunkarr.db npx prisma validate`
- `npx prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --script` returns an empty migration
- `npm test`
- `npm run typecheck`

Docker smoke was not run locally because the Docker CLI is installed but the Docker daemon socket is not available on this machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing topic categorization data in the database.
* **Bug Fixes**
  * Improved filtering performance for download status lookups.
* **Tests**
  * Added coverage to ensure the database bootstrap script stays in sync with the schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->