### PR TITLE
Fail fast on unwritable database volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ image: ghcr.io/rundfunkarr/rundfunkarr:nightly
 Für reproduzierbare Deployments kann statt `latest` auch eine feste Version verwendet werden:
 
 ```yaml
-image: ghcr.io/rundfunkarr/rundfunkarr:1.2.1
+image: ghcr.io/rundfunkarr/rundfunkarr:1.2.2
 ```
 
 Der Git-Tag-Alias mit `v`-Präfix ist ebenfalls verfügbar:
 
 ```bash
-docker pull ghcr.io/rundfunkarr/rundfunkarr:v1.2.1
+docker pull ghcr.io/rundfunkarr/rundfunkarr:v1.2.2
 ```
 
 ### Starten

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
 PUID=${PUID:-1001}
 PGID=${PGID:-1001}
 
@@ -26,7 +31,7 @@ else
     echo "Using existing user '$USER_NAME' for UID $PUID"
 fi
 
-echo "Running as user: $USER_NAME ($(id $USER_NAME))"
+echo "Running as user: $USER_NAME ($(id "$USER_NAME"))"
 
 # Ensure required directories exist with correct permissions
 DOWNLOAD_DIR="${DOWNLOAD_FOLDER_PATH:-/app/downloads}"
@@ -48,14 +53,25 @@ chmod -R 755 "$DOWNLOAD_DIR" "$TEMP_DIR" 2>/dev/null || echo "Note: Could not ch
 echo "Download directory permissions:"
 ls -la "$DOWNLOAD_DIR" 2>&1 || echo "Cannot list $DOWNLOAD_DIR"
 
-# Run database migrations
-echo "Running database migrations..."
+DB_PATH="/app/prisma/data/rundfunkarr.db"
+
+echo "Checking database volume writability..."
+# shellcheck disable=SC2016
+if ! su-exec "$USER_NAME" sh -c 'tmp="$1/.rundfunkarr-write-test.$$"; touch "$tmp" && rm -f "$tmp"' sh /app/prisma/data; then
+    fail "Database directory /app/prisma/data is not writable by UID $PUID/GID $PGID. Fix the host volume ownership/permissions or set PUID/PGID to a user that can write there."
+fi
+
+# shellcheck disable=SC2016
+if [ -e "$DB_PATH" ] && ! su-exec "$USER_NAME" sh -c ': >> "$1"' sh "$DB_PATH"; then
+    fail "Database file $DB_PATH exists but is not writable by UID $PUID/GID $PGID. Fix the file ownership/permissions on the host volume."
+fi
+
+# Initialize and validate the database schema
+echo "Initializing database schema..."
 echo "DATABASE_URL: $DATABASE_URL"
 echo "Checking prisma directory..."
 ls -la /app/prisma/ 2>&1 || echo "Cannot list /app/prisma/"
 ls -la /app/prisma/data/ 2>&1 || echo "Cannot list /app/prisma/data/"
-
-DB_PATH="/app/prisma/data/rundfunkarr.db"
 
 echo "Initializing database at $DB_PATH..."
 if su-exec "$USER_NAME" sqlite3 "$DB_PATH" < /app/init-db.sql 2>&1; then
@@ -64,7 +80,22 @@ if su-exec "$USER_NAME" sqlite3 "$DB_PATH" < /app/init-db.sql 2>&1; then
     chown "$PUID:$PGID" "$DB_PATH" 2>/dev/null || true
     chmod 644 "$DB_PATH" 2>/dev/null || true
 else
-    echo "WARNING: Database initialization failed!"
+    fail "Database initialization failed. Check that /app/prisma/data is writable by UID $PUID/GID $PGID."
+fi
+
+MISSING_TABLES=""
+for table in TvdbSeries TvdbEpisode Download Config GeneratedRuleset TopicCategory; do
+    if ! su-exec "$USER_NAME" sqlite3 "$DB_PATH" "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '$table';" | grep -q 1; then
+        MISSING_TABLES="$MISSING_TABLES $table"
+    fi
+done
+
+if [ -n "$MISSING_TABLES" ]; then
+    fail "Database initialization incomplete. Missing tables:$MISSING_TABLES"
+fi
+
+if ! su-exec "$USER_NAME" sqlite3 "$DB_PATH" "BEGIN IMMEDIATE; CREATE TABLE IF NOT EXISTS __rundfunkarr_write_test (id INTEGER); DROP TABLE __rundfunkarr_write_test; COMMIT;" 2>&1; then
+    fail "Database file $DB_PATH is not writable by UID $PUID/GID $PGID. Fix the host volume ownership/permissions."
 fi
 
 echo "Database directory after migration:"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,10 +68,12 @@ fi
 
 # Initialize and validate the database schema
 echo "Initializing database schema..."
-echo "DATABASE_URL: $DATABASE_URL"
-echo "Checking prisma directory..."
-ls -la /app/prisma/ 2>&1 || echo "Cannot list /app/prisma/"
-ls -la /app/prisma/data/ 2>&1 || echo "Cannot list /app/prisma/data/"
+if [ "${DEBUG:-false}" = "true" ]; then
+    echo "DATABASE_URL: $DATABASE_URL"
+    echo "Checking prisma directory..."
+    ls -la /app/prisma/ 2>&1 || echo "Cannot list /app/prisma/"
+    ls -la /app/prisma/data/ 2>&1 || echo "Cannot list /app/prisma/data/"
+fi
 
 echo "Initializing database at $DB_PATH..."
 if su-exec "$USER_NAME" sqlite3 "$DB_PATH" < /app/init-db.sql 2>&1; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rundfunkarr",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rundfunkarr",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^6.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rundfunkarr",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Rundfunk indexer for Sonarr/Radarr",
   "scripts": {


### PR DESCRIPTION
## Summary
- fail fast when `/app/prisma/data` is not writable by the configured `PUID`/`PGID`
- fail container startup if SQLite bootstrap cannot initialize the database schema
- verify required tables exist before starting the app
- verify the SQLite database can be written after initialization
- bump the app/docs to `1.2.2` so a follow-up release tag can update `latest` cleanly

## Root Cause
The latest issue logs no longer show only a missing `TopicCategory` table. They show `Config` and `Download` missing too, followed by SQLite `attempt to write a readonly database`. That means the mounted database volume is not writable or the bootstrap failed, but the entrypoint currently logs only a warning and starts the app anyway. Users then see noisy Prisma runtime errors instead of the real host-volume permission problem.

A second issue is release visibility: the reporter uses `ghcr.io/rundfunkarr/rundfunkarr:latest`, and this workflow updates `latest` only from `v*` tags. The previous fix is on `main`, but a tagged release is still needed before `:latest` users receive it.

## Validation
- `sh -n entrypoint.sh`
- `shellcheck entrypoint.sh`
- `npm test`
- `npm run typecheck`

Local Docker smoke was not run because the Docker daemon is not available on this machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger startup validation for database setup, including permissions, schema availability, and write access checks.
  * Startup now stops with a clear error when database initialization or validation fails.

* **Documentation**
  * Updated Docker installation examples to reference release `1.2.2`.

* **Chores**
  * Updated the application version to `1.2.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->