### PR TITLE
Fix configurable movie minimum duration

### DIFF
--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getMinDurationSeconds, getCategoriesForTopics } = vi.hoisted(() => ({
+  getMinDurationSeconds: vi.fn(),
+  getCategoriesForTopics: vi.fn(),
+}));
+
+vi.mock("@/lib/settings", () => ({ getMinDurationSeconds }));
+vi.mock("@/services/category", () => ({
+  getCategoriesForTopics,
+}));
+
+import { GET } from "./route";
+
+function apiItem(title: string, duration: number) {
+  return {
+    channel: "ARD",
+    topic: "Documentary",
+    title,
+    description: "",
+    filmlisteTimestamp: 1_700_000_000,
+    duration,
+    size: 1_000_000,
+    url_website: "https://example.com",
+    url_video: `https://example.com/${title}.mp4`,
+    url_video_low: "",
+    url_video_hd: "",
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  getMinDurationSeconds.mockReset();
+  getCategoriesForTopics.mockReset();
+  getCategoriesForTopics.mockResolvedValue(new Map());
+});
+
+describe("movie search API minimum duration", () => {
+  it("uses the configured minimum duration", async () => {
+    getMinDurationSeconds.mockResolvedValue(2700);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          result: { results: [apiItem("Too short", 2699), apiItem("Boundary", 2700)] },
+        })
+      )
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/search?q=Documentary&type=movie")
+    );
+    const body = await response.json();
+
+    expect(body.results.map((item: { title: string }) => item.title)).toEqual(["Boundary"]);
+  });
+
+  it("keeps short movie results when minimum duration is disabled", async () => {
+    getMinDurationSeconds.mockResolvedValue(0);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ result: { results: [apiItem("Short", 120)] } }))
+    );
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/search?q=Documentary&type=movie")
+    );
+    const body = await response.json();
+
+    expect(body.results).toHaveLength(1);
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCategoriesForTopics, CategoryType } from "@/services/category";
+import { getMinDurationSeconds } from "@/lib/settings";
 
 const MEDIATHEK_API_URL = "https://mediathekviewweb.de/api/query";
 
@@ -57,9 +58,8 @@ export async function GET(request: NextRequest) {
     const data = await response.json();
     const items = data.result?.results || [];
 
-    // Filter out m3u8 streams and transform results
-    // For movies: only items >= 60 minutes (3600 seconds)
-    const minDuration = type === "movie" ? 3600 : 0;
+    // Filter out m3u8 streams and apply the configured minimum duration to movies
+    const minDuration = type === "movie" ? await getMinDurationSeconds() : 0;
 
     const filteredItems = items
       .filter(

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findUnique } = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    config: { findUnique },
+  },
+}));
+
+import { clearSettingsCache, getMinDurationSeconds } from "./settings";
+
+beforeEach(() => {
+  clearSettingsCache();
+  findUnique.mockReset();
+});
+
+describe("getMinDurationSeconds", () => {
+  it("uses the configured duration", async () => {
+    findUnique.mockResolvedValue({ value: "2700" });
+
+    await expect(getMinDurationSeconds()).resolves.toBe(2700);
+  });
+
+  it("allows zero to disable minimum-duration filtering", async () => {
+    findUnique.mockResolvedValue({ value: "0" });
+
+    await expect(getMinDurationSeconds()).resolves.toBe(0);
+  });
+
+  it.each([null, { value: "invalid" }, { value: "-1" }])(
+    "falls back to 300 seconds for %j",
+    async (config) => {
+      findUnique.mockResolvedValue(config);
+
+      await expect(getMinDurationSeconds()).resolves.toBe(300);
+    }
+  );
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 // Cache for settings to avoid repeated DB queries
 const settingsCache: Map<string, { value: string; expiry: number }> = new Map();
 const CACHE_TTL = 60 * 1000; // 1 minute
+const DEFAULT_MIN_DURATION_SECONDS = 300;
 
 export async function getSetting(key: string): Promise<string | null> {
   // Check cache first
@@ -65,6 +66,18 @@ export async function getSettings(keys: string[]): Promise<Record<string, string
   }
 
   return result;
+}
+
+export async function getMinDurationSeconds(): Promise<number> {
+  const setting = await getSetting("matching.minDuration");
+  if (setting) {
+    const parsed = parseInt(setting, 10);
+    if (!isNaN(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+
+  return DEFAULT_MIN_DURATION_SECONDS;
 }
 
 export function clearSettingsCache(): void {

--- a/src/services/mediathek.test.ts
+++ b/src/services/mediathek.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ApiResultItem } from "@/types";
+import type { ApiResultItem, TmdbMovieData } from "@/types";
 
 // Keep the unit hermetic: no DB, no network, no ruleset store.
 vi.mock("@/lib/settings", () => ({
   // null -> defaults kick in: quality "all", minDuration 300s, fuzzy/0.7
   getSetting: vi.fn().mockResolvedValue(null),
+  getMinDurationSeconds: vi.fn().mockResolvedValue(300),
 }));
 vi.mock("@/lib/cache", () => ({
   mediathekCache: { get: vi.fn().mockReturnValue(undefined), set: vi.fn() },
@@ -18,11 +19,22 @@ vi.mock("./rulesets", () => ({
   getAllTopics: vi.fn().mockReturnValue([]),
   getOrGenerateRulesetForShow: vi.fn().mockResolvedValue(null),
 }));
+vi.mock("./tmdb", () => ({
+  searchMovieByTitle: vi.fn().mockResolvedValue(null),
+}));
 
-import { fetchSearchResultsByString } from "./mediathek";
+import {
+  fetchMovieSearchByQuery,
+  fetchMovieSearchResults,
+  fetchSearchResultsByString,
+} from "./mediathek";
 import { fetchWithRetry } from "@/lib/fetch-retry";
+import { mediathekCache } from "@/lib/cache";
+import { getMinDurationSeconds } from "@/lib/settings";
 
 const mockedFetch = vi.mocked(fetchWithRetry);
+const mockedGetMinDuration = vi.mocked(getMinDurationSeconds);
+const mockedCacheSet = vi.mocked(mediathekCache.set);
 
 function makeItem(overrides: Partial<ApiResultItem> = {}): ApiResultItem {
   return {
@@ -50,6 +62,7 @@ function mockApi(results: ApiResultItem[]): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockedGetMinDuration.mockResolvedValue(300);
 });
 
 describe("fetchSearchResultsByString – generic result gating", () => {
@@ -83,5 +96,56 @@ describe("fetchSearchResultsByString – generic result gating", () => {
 
     expect(xml).toContain('total="0"');
     expect(xml).not.toContain("<item>");
+  });
+});
+
+describe("fetchMovieSearchByQuery – configured minimum duration", () => {
+  it("includes movies at the configured boundary and rejects shorter results", async () => {
+    mockedGetMinDuration.mockResolvedValue(2700);
+    mockApi([
+      makeItem({ topic: "Too Short", title: "Documentary", duration: 2699 }),
+      makeItem({ topic: "At Boundary", title: "Documentary", duration: 2700 }),
+    ]);
+
+    const xml = await fetchMovieSearchByQuery("Documentary", 100, 0);
+
+    expect(xml).toContain("At.Boundary");
+    expect(xml).not.toContain("Too.Short");
+    expect(mockedCacheSet).toHaveBeenCalledWith(
+      expect.stringContaining("movie_query_Documentary__100_0_all_2700"),
+      expect.any(Object)
+    );
+  });
+});
+
+describe("fetchMovieSearchResults – configured minimum duration", () => {
+  it("applies the configured boundary to TMDB and IMDB-backed searches", async () => {
+    mockedGetMinDuration.mockResolvedValue(2700);
+    mockApi([
+      makeItem({ topic: "Documentary", title: "Documentary", duration: 2699 }),
+      makeItem({
+        topic: "Documentary",
+        title: "Documentary",
+        duration: 2700,
+        url_video: "https://example.com/boundary_720.mp4",
+      }),
+    ]);
+    const movie: TmdbMovieData = {
+      tmdbId: 28,
+      imdbId: "tt0000028",
+      title: "Documentary",
+      germanTitle: "Documentary",
+      runtime: 45,
+      releaseDate: "2026-07-12",
+    };
+
+    const xml = await fetchMovieSearchResults(movie, 100, 0);
+
+    expect(xml).toContain("boundary_720.mp4");
+    expect(xml).not.toContain("show_720.mp4");
+    expect(mockedCacheSet).toHaveBeenCalledWith(
+      expect.stringContaining("movie_28_100_0_all_2700"),
+      expect.any(Object)
+    );
   });
 });

--- a/src/services/mediathek.ts
+++ b/src/services/mediathek.ts
@@ -1,6 +1,6 @@
 import { mediathekCache } from "@/lib/cache";
 import { fetchWithRetry } from "@/lib/fetch-retry";
-import { getSetting } from "@/lib/settings";
+import { getMinDurationSeconds, getSetting } from "@/lib/settings";
 import { getShowInfoByTvdbId } from "./shows";
 import {
   ensureRulesetsLoaded,
@@ -52,17 +52,6 @@ async function getQualityPreference(): Promise<QualityPreference> {
     return setting as QualityPreference;
   }
   return "all"; // Default to all qualities
-}
-
-async function getMinDuration(): Promise<number> {
-  const setting = await getSetting("matching.minDuration");
-  if (setting) {
-    const parsed = parseInt(setting, 10);
-    if (!isNaN(parsed) && parsed >= 0) {
-      return parsed;
-    }
-  }
-  return 300; // Default: 5 minutes
 }
 
 // Keywords that are always skipped (trailers, outtakes, etc.)
@@ -509,7 +498,7 @@ async function applyRulesetFilters(
   tvdbData?: TvdbData
 ): Promise<{ matchedEpisodes: MatchedEpisodeInfo[]; unmatchedItems: ApiResultItem[] }> {
   await ensureRulesetsLoaded();
-  const minDuration = await getMinDuration();
+  const minDuration = await getMinDurationSeconds();
   const matchingSettings = await getMatchingSettings();
   console.log(
     `[Mediathek] Matching settings: strategy=${matchingSettings.strategy}, threshold=${matchingSettings.threshold}, minDuration=${minDuration}s`
@@ -704,7 +693,7 @@ export async function fetchSearchResultsById(
   offset: number
 ): Promise<string> {
   const quality = await getQualityPreference();
-  const minDuration = await getMinDuration();
+  const minDuration = await getMinDurationSeconds();
   const matchingSettings = await getMatchingSettings();
   console.log(
     `[Mediathek] fetchSearchResultsById: tvdbId=${tvdbData.id}, name="${tvdbData.name}", germanName="${tvdbData.germanName}", season=${season}, episode=${episodeNumber}, quality=${quality}, minDuration=${minDuration}`
@@ -791,7 +780,7 @@ export async function fetchSearchResultsByString(
   // (API query, cache keys, and generic gating) so behavior stays consistent.
   const trimmedQ = q?.trim() || null;
   const quality = await getQualityPreference();
-  const minDuration = await getMinDuration();
+  const minDuration = await getMinDurationSeconds();
   const matchingSettings = await getMatchingSettings();
   const cacheKey = `q_${trimmedQ ?? "null"}_${season ?? "null"}_${limit}_${offset}_${quality}_${minDuration}_${matchingSettings.threshold}`;
 
@@ -858,7 +847,7 @@ export async function fetchSearchResultsByString(
 
 export async function fetchSearchResultsForRssSync(limit: number, offset: number): Promise<string> {
   const quality = await getQualityPreference();
-  const minDuration = await getMinDuration();
+  const minDuration = await getMinDurationSeconds();
   const matchingSettings = await getMatchingSettings();
   const cacheKey = `rss_${limit}_${offset}_${quality}_${minDuration}_${matchingSettings.threshold}`;
 
@@ -911,11 +900,12 @@ export async function fetchMovieSearchResults(
   offset: number
 ): Promise<string> {
   const quality = await getQualityPreference();
+  const minDuration = await getMinDurationSeconds();
   console.log(
-    `[Mediathek] fetchMovieSearchResults: tmdbId=${movieData.tmdbId}, title="${movieData.title}", germanTitle="${movieData.germanTitle}", runtime=${movieData.runtime} min, quality=${quality}`
+    `[Mediathek] fetchMovieSearchResults: tmdbId=${movieData.tmdbId}, title="${movieData.title}", germanTitle="${movieData.germanTitle}", runtime=${movieData.runtime} min, quality=${quality}, minDuration=${minDuration}s`
   );
 
-  const cacheKey = `movie_${movieData.tmdbId}_${limit}_${offset}_${quality}`;
+  const cacheKey = `movie_${movieData.tmdbId}_${limit}_${offset}_${quality}_${minDuration}`;
 
   const cached = mediathekCache.get(cacheKey);
   if (cached && typeof cached === "object" && "response" in cached) {
@@ -999,7 +989,7 @@ export async function fetchMovieSearchResults(
   }
 
   // Match results against movie data
-  const matchResults = await matchMovieItems(filteredResults, movieData);
+  const matchResults = await matchMovieItems(filteredResults, movieData, minDuration);
 
   if (matchResults.length === 0) {
     console.log(`[Mediathek] No matches found for movie`);
@@ -1032,7 +1022,7 @@ export async function fetchMovieSearchByQuery(
   offset: number
 ): Promise<string> {
   const quality = await getQualityPreference();
-  const MOVIE_MIN_DURATION = 60 * 60; // 60 minutes in seconds
+  const minDuration = await getMinDurationSeconds();
 
   // Strip trailing year from query (Radarr sends "Movie Title 2018")
   const cleanedQuery = query.replace(/\s+\d{4}$/, "").trim();
@@ -1040,7 +1030,7 @@ export async function fetchMovieSearchByQuery(
   const searchYear = yearMatch ? parseInt(yearMatch[1], 10) : null;
 
   console.log(
-    `[Mediathek] fetchMovieSearchByQuery: query="${query}", cleanedQuery="${cleanedQuery}", year=${searchYear}, quality=${quality}, minDuration=${MOVIE_MIN_DURATION}s`
+    `[Mediathek] fetchMovieSearchByQuery: query="${query}", cleanedQuery="${cleanedQuery}", year=${searchYear}, quality=${quality}, minDuration=${minDuration}s`
   );
 
   // Try to find the movie on TMDB to get IDs for Radarr matching
@@ -1051,7 +1041,7 @@ export async function fetchMovieSearchByQuery(
     );
   }
 
-  const cacheKey = `movie_query_${cleanedQuery}_${searchYear || ""}_${limit}_${offset}_${quality}`;
+  const cacheKey = `movie_query_${cleanedQuery}_${searchYear || ""}_${limit}_${offset}_${quality}_${minDuration}`;
 
   const cached = mediathekCache.get(cacheKey);
   if (cached && typeof cached === "object" && "response" in cached) {
@@ -1098,16 +1088,16 @@ export async function fetchMovieSearchByQuery(
     return response;
   }
 
-  // Filter: skip trailers, m3u8, and apply movie minimum duration (60 min)
+  // Filter: skip trailers, m3u8, and apply the configured minimum duration
   const filteredResults = results.filter((item) => {
     if (item.url_video.endsWith(".m3u8")) return false;
     if (SKIP_KEYWORDS.some((kw) => item.title.includes(kw))) return false;
-    if (item.duration < MOVIE_MIN_DURATION) return false;
+    if (minDuration > 0 && item.duration < minDuration) return false;
     return true;
   });
 
   console.log(
-    `[Mediathek] Results after movie filtering (min ${MOVIE_MIN_DURATION / 60} min): ${filteredResults.length}`
+    `[Mediathek] Results after movie filtering (min ${minDuration}s): ${filteredResults.length}`
   );
 
   if (filteredResults.length === 0) {

--- a/src/services/movie-matcher.test.ts
+++ b/src/services/movie-matcher.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiResultItem, TmdbMovieData } from "@/types";
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+}));
+
+import { matchMovieItems } from "./movie-matcher";
+
+const movie: TmdbMovieData = {
+  tmdbId: 28,
+  imdbId: "tt0000028",
+  title: "Documentary",
+  germanTitle: "Documentary",
+  runtime: 45,
+  releaseDate: "2026-07-12",
+};
+
+function makeItem(duration: number, id: string): ApiResultItem {
+  return {
+    channel: "ARD",
+    topic: "Documentary",
+    title: "Documentary",
+    description: "",
+    filmlisteTimestamp: 1_700_000_000,
+    duration,
+    size: 1_000_000,
+    url_website: `https://example.com/${id}`,
+    url_video: `https://example.com/${id}.mp4`,
+    url_video_low: "",
+    url_video_hd: "",
+  };
+}
+
+describe("matchMovieItems – minimum duration", () => {
+  it("compares durations in seconds at the configured boundary", async () => {
+    const matches = await matchMovieItems(
+      [makeItem(2699, "short"), makeItem(2700, "boundary")],
+      movie,
+      2700
+    );
+
+    expect(matches.map((match) => match.item.url_video)).toEqual([
+      "https://example.com/boundary.mp4",
+    ]);
+  });
+
+  it("does not filter by duration when the setting is zero", async () => {
+    const matches = await matchMovieItems([makeItem(120, "short")], movie, 0);
+
+    expect(matches).toHaveLength(1);
+  });
+});

--- a/src/services/movie-matcher.ts
+++ b/src/services/movie-matcher.ts
@@ -88,7 +88,8 @@ export interface MovieMatchResult {
  */
 export async function matchMovieItems(
   items: ApiResultItem[],
-  movieData: TmdbMovieData
+  movieData: TmdbMovieData,
+  minDurationSeconds: number
 ): Promise<MovieMatchResult[]> {
   const durationTolerance = await getDurationTolerance();
   const results: MovieMatchResult[] = [];
@@ -113,8 +114,7 @@ export async function matchMovieItems(
     const itemDurationMinutes = Math.floor(item.duration / 60);
     const durationDiff = Math.abs(movieRuntimeMinutes - itemDurationMinutes);
 
-    // Check if it's a movie-length item (at least 60 minutes)
-    if (itemDurationMinutes < 60) continue;
+    if (minDurationSeconds > 0 && item.duration < minDurationSeconds) continue;
 
     let titleMatch: "exact" | "fuzzy" | "partial" | null = null;
     let titleScore = 0;


### PR DESCRIPTION
## Summary

- use `matching.minDuration` consistently for Radarr movie searches and the movie search UI
- compare movie durations in seconds and allow `0` to disable minimum-duration filtering
- include the configured minimum duration in movie response cache keys
- add regression coverage for configured boundaries, disabled filtering, fallback values, and all movie search paths

## Root cause

Movie searches still contained hard-coded 60-minute filters in the matcher, Radarr query search, and UI search route. Those filters bypassed the existing `matching.minDuration` setting and excluded shorter documentaries.

## Validation

- `npm test` (62 tests)
- `npm run typecheck`
- `npm run lint` (passes with one pre-existing warning in `src/services/ruleset-generator.ts`)
- `npm run format:check`

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable minimum movie duration filtering across movie matching and search results.
  - Minimum duration settings now support custom non-negative values, including `0` to disable filtering.
  - Searches include results exactly at the configured duration threshold.
  - Cached search results now reflect changes to the minimum-duration setting.

- **Bug Fixes**
  - Replaced the fixed 60-minute movie duration requirement with the configured setting.
  - Invalid or missing duration settings now use a safe default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->