### PR TITLE
Allow disabling automatic MKV conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Rundfunk-Indexer für Sonarr/Radarr - Automatischer Download von ARD, ZDF und an
 
 - **Newznab-kompatibler Indexer** - Funktioniert mit Prowlarr, NZB Hydra, Sonarr und Radarr
 - **SABnzbd-kompatibler Downloader** - Direkter HTTP-Download von den Mediatheken
-- **Automatische MKV-Konvertierung** - FFmpeg-Integration mit deutschen Sprachmetadaten
+- **Optionale MKV-Konvertierung** - FFmpeg-Integration mit deutschen Sprachmetadaten
 - **Flexible Metadaten-Quellen** - Lokale Datenbank, TVDB oder TMDB
 - **Community-Rulesets** - Lokale Rulesets via Pull Request erweiterbar
 - **SQLite-Datenbank** - Persistente Speicherung von Cache und Download-Historie
@@ -120,7 +120,7 @@ RundfunkArr bietet eine vollständige Web-Oberfläche mit:
 - **Suche** - Direkte Suche in den Mediatheken
 - **Downloads** - Queue und Historie verwalten
 - **Settings** - Alle Einstellungen konfigurieren:
-  - Download-Pfad und Qualitäts-Präferenzen
+  - Download-Pfad, Qualitäts-Präferenzen und optionale MKV-Konvertierung
   - API Keys für TVDB/TMDB
   - Matching-Strategie und Schwellwerte
   - Cache-TTL Einstellungen

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -10,6 +10,7 @@ const DEFAULT_SETTINGS: Record<string, string> = {
   // General
   "download.path": "/downloads",
   "download.quality": "all",
+  "download.convertToMkv": "true",
 
   // API Keys
   "api.tvdb.key": "",

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -277,9 +277,28 @@ export default function SettingsPage() {
                       Welche Qualitäten sollen im Newznab-Feed angezeigt werden?
                     </p>
                   </div>
+                  <label className="flex items-center justify-between gap-4 rounded-md border border-input p-3">
+                    <span>
+                      <span className="block text-sm font-medium">MP4 in MKV konvertieren</span>
+                      <span className="block text-xs text-muted-foreground mt-1">
+                        Deaktivieren, wenn ein externes Tool wie Tdarr die Medienverarbeitung
+                        übernimmt. Heruntergeladene MP4-Dateien bleiben dann unverändert.
+                      </span>
+                    </span>
+                    <input
+                      type="checkbox"
+                      checked={getFieldValue("download.convertToMkv") !== "false"}
+                      onChange={(e) =>
+                        setFieldValue("download.convertToMkv", String(e.target.checked))
+                      }
+                      className="h-4 w-4 shrink-0 accent-primary"
+                    />
+                  </label>
 
                   <Button
-                    onClick={() => handleSave(["download.path", "download.quality"])}
+                    onClick={() =>
+                      handleSave(["download.path", "download.quality", "download.convertToMkv"])
+                    }
                     disabled={isSaving}
                   >
                     {isSaving ? (

--- a/src/contexts/settings-context.tsx
+++ b/src/contexts/settings-context.tsx
@@ -6,6 +6,7 @@ interface Settings {
   // General
   "download.path": string;
   "download.quality": string;
+  "download.convertToMkv": string;
 
   // API Keys
   "api.tvdb.key": string;

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { clearSettingsCache, getMinDurationSeconds } from "./settings";
+import { clearSettingsCache, getMinDurationSeconds, isMkvConversionEnabled } from "./settings";
 
 beforeEach(() => {
   clearSettingsCache();
@@ -38,4 +38,21 @@ describe("getMinDurationSeconds", () => {
       await expect(getMinDurationSeconds()).resolves.toBe(300);
     }
   );
+});
+
+describe("isMkvConversionEnabled", () => {
+  it("defaults to enabled when the setting does not exist", async () => {
+    findUnique.mockResolvedValue(null);
+
+    await expect(isMkvConversionEnabled()).resolves.toBe(true);
+  });
+
+  it.each([
+    ["true", true],
+    ["false", false],
+  ])("maps %s to %s", async (value, expected) => {
+    findUnique.mockResolvedValue({ value });
+
+    await expect(isMkvConversionEnabled()).resolves.toBe(expected);
+  });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -80,6 +80,10 @@ export async function getMinDurationSeconds(): Promise<number> {
   return DEFAULT_MIN_DURATION_SECONDS;
 }
 
+export async function isMkvConversionEnabled(): Promise<boolean> {
+  return (await getSetting("download.convertToMkv")) !== "false";
+}
+
 export function clearSettingsCache(): void {
   settingsCache.clear();
 }

--- a/src/server/download-manager.test.ts
+++ b/src/server/download-manager.test.ts
@@ -3,14 +3,21 @@ import { access, mkdtemp, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 
-const { configFindUnique, downloadCount, downloadFindUnique, downloadUpdate, convertMp4ToMkv } =
-  vi.hoisted(() => ({
-    configFindUnique: vi.fn(),
-    downloadCount: vi.fn(),
-    downloadFindUnique: vi.fn(),
-    downloadUpdate: vi.fn(),
-    convertMp4ToMkv: vi.fn(),
-  }));
+const {
+  configFindUnique,
+  downloadCount,
+  downloadFindUnique,
+  downloadUpdate,
+  ffmpegModuleLoaded,
+  convertMp4ToMkv,
+} = vi.hoisted(() => ({
+  configFindUnique: vi.fn(),
+  downloadCount: vi.fn(),
+  downloadFindUnique: vi.fn(),
+  downloadUpdate: vi.fn(),
+  ffmpegModuleLoaded: vi.fn(),
+  convertMp4ToMkv: vi.fn(),
+}));
 
 vi.mock("@/lib/db", () => ({
   prisma: {
@@ -23,7 +30,10 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-vi.mock("./ffmpeg", () => ({ convertMp4ToMkv }));
+vi.mock("./ffmpeg", () => {
+  ffmpegModuleLoaded();
+  return { convertMp4ToMkv };
+});
 
 import { clearSettingsCache } from "@/lib/settings";
 import { processDownload } from "./download-manager";
@@ -81,6 +91,7 @@ describe("processDownload", () => {
 
     await processDownload("download-1");
 
+    expect(ffmpegModuleLoaded).not.toHaveBeenCalled();
     expect(convertMp4ToMkv).not.toHaveBeenCalled();
     await expect(readFile(path.join(testRoot, category, `${title}.mp4`))).resolves.toEqual(
       Buffer.from(mediaBytes)

--- a/src/server/download-manager.test.ts
+++ b/src/server/download-manager.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { access, mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+
+const { configFindUnique, downloadCount, downloadFindUnique, downloadUpdate, convertMp4ToMkv } =
+  vi.hoisted(() => ({
+    configFindUnique: vi.fn(),
+    downloadCount: vi.fn(),
+    downloadFindUnique: vi.fn(),
+    downloadUpdate: vi.fn(),
+    convertMp4ToMkv: vi.fn(),
+  }));
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    config: { findUnique: configFindUnique },
+    download: {
+      count: downloadCount,
+      findUnique: downloadFindUnique,
+      update: downloadUpdate,
+    },
+  },
+}));
+
+vi.mock("./ffmpeg", () => ({ convertMp4ToMkv }));
+
+import { clearSettingsCache } from "@/lib/settings";
+import { processDownload } from "./download-manager";
+
+let testRoot: string;
+
+beforeEach(async () => {
+  clearSettingsCache();
+  configFindUnique.mockReset();
+  downloadCount.mockReset();
+  downloadFindUnique.mockReset();
+  downloadUpdate.mockReset();
+  convertMp4ToMkv.mockReset();
+
+  testRoot = await mkdtemp(path.join(tmpdir(), "rundfunkarr-download-manager-"));
+  vi.stubEnv("DOWNLOAD_TEMP_PATH", path.join(testRoot, "incomplete"));
+  vi.stubEnv("DOWNLOAD_FOLDER_PATH_MAPPING", "/mapped/downloads");
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+describe("processDownload", () => {
+  it("keeps MP4 files unchanged when MKV conversion is disabled", async () => {
+    const mediaBytes = new Uint8Array([1, 2, 3, 4]);
+    const title = "Show.S01E01";
+    const category = "sonarr";
+
+    configFindUnique.mockImplementation(({ where }: { where: { key: string } }) => {
+      if (where.key === "download.path") return Promise.resolve({ value: testRoot });
+      if (where.key === "download.convertToMkv") return Promise.resolve({ value: "false" });
+      return Promise.resolve(null);
+    });
+    downloadFindUnique.mockResolvedValue({
+      id: "download-1",
+      title,
+      category,
+      status: "queued",
+      url: "https://example.com/video.mp4",
+    });
+    downloadUpdate.mockResolvedValue({});
+    downloadCount.mockResolvedValue(0);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(mediaBytes, {
+          status: 200,
+          headers: { "content-length": String(mediaBytes.byteLength) },
+        })
+      )
+    );
+
+    await processDownload("download-1");
+
+    expect(convertMp4ToMkv).not.toHaveBeenCalled();
+    await expect(readFile(path.join(testRoot, category, `${title}.mp4`))).resolves.toEqual(
+      Buffer.from(mediaBytes)
+    );
+    await expect(access(path.join(testRoot, category, `${title}.mkv`))).rejects.toThrow();
+    expect(downloadUpdate).toHaveBeenCalledWith({
+      where: { id: "download-1" },
+      data: expect.objectContaining({
+        status: "completed",
+        filePath: path.join("/mapped/downloads", category, `${title}.mp4`),
+      }),
+    });
+  });
+});

--- a/src/server/download-manager.ts
+++ b/src/server/download-manager.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db";
-import { convertMp4ToMkv, ensureFfmpegExists } from "./ffmpeg";
+import { isMkvConversionEnabled } from "@/lib/settings";
+import { convertMp4ToMkv } from "./ffmpeg";
 import * as fs from "fs/promises";
 import { createWriteStream } from "fs";
 import * as path from "path";
@@ -53,9 +54,6 @@ class Semaphore {
 const downloadSemaphore = new Semaphore(MAX_CONCURRENT_DOWNLOADS);
 let isProcessing = false;
 let processingPromise: Promise<void> | null = null;
-
-// Initialize FFmpeg on startup
-ensureFfmpegExists().catch(console.error);
 
 export async function startDownloadProcessing(): Promise<void> {
   if (isProcessing) {
@@ -152,8 +150,8 @@ async function processDownload(downloadId: string): Promise<void> {
 
     console.log(`[Download] File downloaded to temp: ${mp4Path}`);
 
-    // Convert to MKV if it's an MP4
-    if (fileExtension === ".mp4") {
+    // Convert MP4 files to MKV unless the user disabled this step.
+    if (fileExtension.toLowerCase() === ".mp4" && (await isMkvConversionEnabled())) {
       // Convert in temp folder first
       const tempMkvPath = path.join(downloadTempPath, `${download.title}.mkv`);
       const finalMkvPath = path.join(categoryDir, `${download.title}.mkv`);
@@ -208,11 +206,16 @@ async function processDownload(downloadId: string): Promise<void> {
         `[Download] Completed: ${download.title} (${Math.round(stats.size / 1024 / 1024)}MB in ${downloadTime}s)`
       );
     } else {
-      // Non-MP4 file, move to final location
+      // Keep non-MP4 files and MP4 files with disabled conversion unchanged.
       const finalPath = path.join(categoryDir, `${download.title}${fileExtension}`);
       await fs.rename(mp4Path, finalPath);
 
       const stats = await fs.stat(finalPath);
+
+      const downloadFolderMapping = process.env.DOWNLOAD_FOLDER_PATH_MAPPING;
+      const storagePath = downloadFolderMapping
+        ? path.join(downloadFolderMapping, download.category, `${download.title}${fileExtension}`)
+        : finalPath;
 
       await prisma.download.update({
         where: { id: downloadId },
@@ -220,7 +223,7 @@ async function processDownload(downloadId: string): Promise<void> {
           status: "completed",
           progress: 100,
           size: stats.size,
-          filePath: finalPath,
+          filePath: storagePath,
           completedAt: new Date(),
         },
       });

--- a/src/server/download-manager.ts
+++ b/src/server/download-manager.ts
@@ -1,6 +1,5 @@
 import { prisma } from "@/lib/db";
 import { isMkvConversionEnabled } from "@/lib/settings";
-import { convertMp4ToMkv } from "./ffmpeg";
 import * as fs from "fs/promises";
 import { createWriteStream } from "fs";
 import * as path from "path";
@@ -163,6 +162,7 @@ async function processDownload(downloadId: string): Promise<void> {
         data: { status: "converting" },
       });
 
+      const { convertMp4ToMkv } = await import("./ffmpeg");
       const conversionResult = await convertMp4ToMkv(mp4Path, tempMkvPath);
 
       if (!conversionResult.success) {


### PR DESCRIPTION
## Summary

- add a default-on setting for automatic MP4-to-MKV conversion
- keep downloaded MP4 files unchanged when conversion is disabled
- avoid eager FFmpeg initialization so disabled conversion performs no FFmpeg work
- preserve download path mapping and document the optional conversion behavior

## Why

Users who already process media with tools such as Tdarr should be able to skip RundfunkArr's conversion step and avoid unnecessary CPU time and disk I/O.

## Validation

- `npm test` (65 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- manually verified the setting default, persistence, and reload behavior through the UI and `/api/settings`

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting to enable or disable MP4-to-MKV conversion.
  - Conversion is enabled by default and can be controlled from General Settings.
  - MP4 files retain their original format when conversion is disabled.

- **Bug Fixes**
  - Conversion now applies consistently to `.mp4` files regardless of letter casing.
  - Downloaded files retain their correct paths when conversion is skipped.

- **Documentation**
  - Clarified that MKV conversion is optional in the README and settings documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->