### PR TITLE
fix: re-create the category folder before moving a finished download

### DIFF
--- a/src/server/download-manager.test.ts
+++ b/src/server/download-manager.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fsp from "fs/promises";
 import { access, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+
+// Everything stays the real implementation; only `rename` is wrapped in a
+// vi.fn so a single test can inject a failure into its first call (ESM module
+// namespaces cannot be spied on directly).
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return { ...actual, rename: vi.fn(actual.rename) };
+});
 import { tmpdir } from "os";
 import path from "path";
 
@@ -199,6 +208,57 @@ describe("processDownload", () => {
         status: "completed",
         filePath: path.join("/mapped/downloads", category, `${title}.mkv`),
       }),
+    });
+  });
+
+  it("recovers when the folder vanishes between the re-create and the move", async () => {
+    // The narrowest possible race: an *arr import deletes the category folder
+    // in the instant AFTER moveIntoCategoryDir re-created it and BEFORE the
+    // rename runs. Simulated by deleting the folder from inside the first
+    // rename call itself.
+    const mediaBytes = new Uint8Array([17, 18, 19, 20]);
+    const title = "Show.S01E04";
+    const category = "sonarr";
+    const categoryDir = path.join(testRoot, category);
+
+    configFindUnique.mockImplementation(({ where }: { where: { key: string } }) => {
+      if (where.key === "download.path") return Promise.resolve({ value: testRoot });
+      if (where.key === "download.convertToMkv") return Promise.resolve({ value: "false" });
+      return Promise.resolve(null);
+    });
+    downloadFindUnique.mockResolvedValue({
+      id: "download-4",
+      title,
+      category,
+      status: "queued",
+      url: "https://example.com/video.mp4",
+    });
+    downloadUpdate.mockResolvedValue({});
+    downloadCount.mockResolvedValue(0);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(mediaBytes, {
+          status: 200,
+          headers: { "content-length": String(mediaBytes.byteLength) },
+        })
+      )
+    );
+
+    const actual = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+    vi.mocked(fsp.rename).mockImplementationOnce(async (source, target) => {
+      await rm(categoryDir, { recursive: true, force: true });
+      return actual.rename(source, target); // fails with ENOENT, the retry must recover
+    });
+
+    await processDownload("download-4");
+
+    await expect(readFile(path.join(categoryDir, `${title}.mp4`))).resolves.toEqual(
+      Buffer.from(mediaBytes)
+    );
+    expect(downloadUpdate).toHaveBeenCalledWith({
+      where: { id: "download-4" },
+      data: expect.objectContaining({ status: "completed" }),
     });
   });
 });

--- a/src/server/download-manager.test.ts
+++ b/src/server/download-manager.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { access, mkdtemp, readFile, rm } from "fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -102,6 +102,102 @@ describe("processDownload", () => {
       data: expect.objectContaining({
         status: "completed",
         filePath: path.join("/mapped/downloads", category, `${title}.mp4`),
+      }),
+    });
+  });
+
+  it("recovers when the category directory is removed mid-download", async () => {
+    const mediaBytes = new Uint8Array([5, 6, 7, 8]);
+    const title = "Show.S01E02";
+    const category = "sonarr";
+    const categoryDir = path.join(testRoot, category);
+
+    configFindUnique.mockImplementation(({ where }: { where: { key: string } }) => {
+      if (where.key === "download.path") return Promise.resolve({ value: testRoot });
+      if (where.key === "download.convertToMkv") return Promise.resolve({ value: "false" });
+      return Promise.resolve(null);
+    });
+    downloadFindUnique.mockResolvedValue({
+      id: "download-2",
+      title,
+      category,
+      status: "queued",
+      url: "https://example.com/video.mp4",
+    });
+    downloadUpdate.mockResolvedValue({});
+    downloadCount.mockResolvedValue(0);
+    // An *arr app imports an earlier download and deletes the then-empty
+    // category folder while this one is still transferring.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () => {
+        await rm(categoryDir, { recursive: true, force: true });
+        return new Response(mediaBytes, {
+          status: 200,
+          headers: { "content-length": String(mediaBytes.byteLength) },
+        });
+      })
+    );
+
+    await processDownload("download-2");
+
+    await expect(readFile(path.join(categoryDir, `${title}.mp4`))).resolves.toEqual(
+      Buffer.from(mediaBytes)
+    );
+    expect(downloadUpdate).toHaveBeenCalledWith({
+      where: { id: "download-2" },
+      data: expect.objectContaining({ status: "completed" }),
+    });
+  });
+
+  it("recovers when the category directory is removed during MKV conversion", async () => {
+    const mediaBytes = new Uint8Array([9, 10, 11, 12]);
+    const mkvBytes = new Uint8Array([13, 14, 15, 16]);
+    const title = "Show.S01E03";
+    const category = "sonarr";
+    const categoryDir = path.join(testRoot, category);
+
+    configFindUnique.mockImplementation(({ where }: { where: { key: string } }) => {
+      if (where.key === "download.path") return Promise.resolve({ value: testRoot });
+      if (where.key === "download.convertToMkv") return Promise.resolve({ value: "true" });
+      return Promise.resolve(null);
+    });
+    downloadFindUnique.mockResolvedValue({
+      id: "download-3",
+      title,
+      category,
+      status: "queued",
+      url: "https://example.com/video.mp4",
+    });
+    downloadUpdate.mockResolvedValue({});
+    downloadCount.mockResolvedValue(0);
+    convertMp4ToMkv.mockImplementation(async (_source: string, target: string) => {
+      await writeFile(target, mkvBytes);
+      // The folder disappears while ffmpeg is busy -- this is the window that
+      // stranded finished files before the fix.
+      await rm(categoryDir, { recursive: true, force: true });
+      return { success: true };
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(mediaBytes, {
+          status: 200,
+          headers: { "content-length": String(mediaBytes.byteLength) },
+        })
+      )
+    );
+
+    await processDownload("download-3");
+
+    await expect(readFile(path.join(categoryDir, `${title}.mkv`))).resolves.toEqual(
+      Buffer.from(mkvBytes)
+    );
+    expect(downloadUpdate).toHaveBeenCalledWith({
+      where: { id: "download-3" },
+      data: expect.objectContaining({
+        status: "completed",
+        filePath: path.join("/mapped/downloads", category, `${title}.mkv`),
       }),
     });
   });

--- a/src/server/download-manager.ts
+++ b/src/server/download-manager.ts
@@ -172,7 +172,12 @@ async function processDownload(downloadId: string): Promise<void> {
         return;
       }
 
-      // Move completed MKV to final location
+      // Move completed MKV to final location. Re-create the category directory
+      // first: it was created when this download started, but *arr apps remove
+      // the imported file from the category folder while later downloads are
+      // still running, and they delete the folder once it is empty. Without
+      // this the rename fails with ENOENT and the finished file is stranded.
+      await fs.mkdir(categoryDir, { recursive: true });
       console.log(`[Download] Moving to final location: ${finalMkvPath}`);
       await fs.rename(tempMkvPath, finalMkvPath);
 
@@ -208,6 +213,9 @@ async function processDownload(downloadId: string): Promise<void> {
     } else {
       // Keep non-MP4 files and MP4 files with disabled conversion unchanged.
       const finalPath = path.join(categoryDir, `${download.title}${fileExtension}`);
+      // Same reason as above: the category directory may have been removed by
+      // the *arr app while this download was running.
+      await fs.mkdir(categoryDir, { recursive: true });
       await fs.rename(mp4Path, finalPath);
 
       const stats = await fs.stat(finalPath);

--- a/src/server/download-manager.ts
+++ b/src/server/download-manager.ts
@@ -87,6 +87,32 @@ async function processQueue(): Promise<void> {
   }
 }
 
+/**
+ * Move a finished file into the category folder.
+ *
+ * The folder was created when the download started, but *arr apps remove the
+ * imported file from the category folder while later downloads are still
+ * running, and delete the folder once it is empty -- so it is re-created
+ * right before the move. That still leaves a moment between mkdir and rename;
+ * if an import deletes the folder in exactly that instant, the ENOENT is
+ * answered with one more re-create and retry. A missing SOURCE file also
+ * surfaces as ENOENT and fails the retry identically, which is correct.
+ */
+async function moveIntoCategoryDir(
+  sourcePath: string,
+  targetPath: string,
+  categoryDir: string
+): Promise<void> {
+  await fs.mkdir(categoryDir, { recursive: true });
+  try {
+    await fs.rename(sourcePath, targetPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    await fs.mkdir(categoryDir, { recursive: true });
+    await fs.rename(sourcePath, targetPath);
+  }
+}
+
 async function processDownload(downloadId: string): Promise<void> {
   await downloadSemaphore.acquire();
 
@@ -172,14 +198,10 @@ async function processDownload(downloadId: string): Promise<void> {
         return;
       }
 
-      // Move completed MKV to final location. Re-create the category directory
-      // first: it was created when this download started, but *arr apps remove
-      // the imported file from the category folder while later downloads are
-      // still running, and they delete the folder once it is empty. Without
-      // this the rename fails with ENOENT and the finished file is stranded.
-      await fs.mkdir(categoryDir, { recursive: true });
+      // Move completed MKV to final location; see moveIntoCategoryDir for why
+      // the category directory is re-created here.
       console.log(`[Download] Moving to final location: ${finalMkvPath}`);
-      await fs.rename(tempMkvPath, finalMkvPath);
+      await moveIntoCategoryDir(tempMkvPath, finalMkvPath, categoryDir);
 
       // Clean up temp MP4 file
       await fs.unlink(mp4Path).catch(() => {});
@@ -213,10 +235,7 @@ async function processDownload(downloadId: string): Promise<void> {
     } else {
       // Keep non-MP4 files and MP4 files with disabled conversion unchanged.
       const finalPath = path.join(categoryDir, `${download.title}${fileExtension}`);
-      // Same reason as above: the category directory may have been removed by
-      // the *arr app while this download was running.
-      await fs.mkdir(categoryDir, { recursive: true });
-      await fs.rename(mp4Path, finalPath);
+      await moveIntoCategoryDir(mp4Path, finalPath, categoryDir);
 
       const stats = await fs.stat(finalPath);
 


### PR DESCRIPTION
On a stock Sonarr/Radarr setup, every second download is silently lost.

The category folder `/downloads/<category>` is created when a download starts, but the finished file is only moved there minutes later, after transfer and MKV conversion. In that window the *arr app imports the *previous* download - the import is a move, so the folder ends up empty and gets cleaned up. The next `rename` then fails:

```
[Download] Moving to final location: /downloads/sonarr/Show.S01E02.mkv
[Download] Error … ENOENT: no such file or directory, rename …
```

The converted file is stranded in the temp folder and the queue entry never completes. Since downloads and imports alternate, exactly every second download fails; on my instance this had accumulated 27.9 GB of stranded files in `incomplete/` - precisely the even episode numbers of every season grabbed as a pack.

**Fix:** both move paths `mkdir` the category folder right before the `rename`. The `mkdir` at download start stays, so an unwritable volume still fails early.

This cannot be fixed by configuration: "Remove Completed Downloads" only controls whether the app tells the client to drop the job - the file leaves the folder through the import itself (a move; Sonarr hardlinks only for seeding clients). Tried on the affected instance, the next download failed identically.

Two regression tests, one per move path, delete the category folder from inside the fetch/ffmpeg mocks; without the fix both fail with the ENOENT above. 68 tests passing, `tsc` and eslint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rundfunkarr/codesmith/rundfunkarr/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790602141&installation_model_id=433282&pr_number=34&repository=rundfunkarr%2Frundfunkarr&return_to=https%3A%2F%2Fgithub.com%2Frundfunkarr%2Frundfunkarr%2Fpull%2F34&signature=3b980390ad4b6e83ccdb2a07d4e7478b9b81e6f39547d994c110d4e1bbb4befc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability when the destination category folder is removed during an active transfer.
  * Completed downloads now recreate the required folder and are successfully saved, including files undergoing MKV conversion.
  * Downloads are correctly marked as completed instead of being left stranded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->