### PR TITLE
Fix Prowlarr category validation for Radarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ Für Shows die nicht in TVDB/TMDB sind, können Einträge in `data/shows.json` h
 3. Port: `6767`
 4. API Key: beliebig
 
+Prowlarr synchronisiert nur den Indexer zu Sonarr und Radarr. Richte RundfunkArr
+als Download Client zusätzlich direkt in jeder *arr App ein. Ein in Prowlarr
+konfigurierter Download Client wird nur für manuelle Downloads aus Prowlarr
+verwendet.
+
 ## Rulesets & Shows hinzufügen
 
 ### Neue Show hinzufügen

--- a/src/app/api/newznab/route.test.ts
+++ b/src/app/api/newznab/route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mediathekMocks = vi.hoisted(() => ({
+  fetchSearchResultsById: vi.fn(),
+  fetchSearchResultsByString: vi.fn(),
+  fetchSearchResultsForRssSync: vi.fn(),
+  fetchMovieSearchResults: vi.fn(),
+  fetchMovieSearchByQuery: vi.fn(),
+}));
+const showMocks = vi.hoisted(() => ({
+  getShowInfoByTvdbId: vi.fn(),
+}));
+const tmdbMocks = vi.hoisted(() => ({
+  getMovieInfoByTmdbId: vi.fn(),
+  getMovieInfoByImdbId: vi.fn(),
+}));
+
+vi.mock("@/services/mediathek", () => mediathekMocks);
+vi.mock("@/services/shows", () => showMocks);
+vi.mock("@/services/tmdb", () => tmdbMocks);
+
+import { GET } from "./route";
+
+const EMPTY_RSS = `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel><newznab:response offset="0" total="0"/></channel>
+</rss>`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mediathekMocks.fetchSearchResultsForRssSync.mockResolvedValue(EMPTY_RSS);
+});
+
+describe("Newznab indexer validation", () => {
+  it("returns a movie-category result for the Radarr sync request", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/newznab/api?t=search&extended=1&cat=2040,2030,2000&apikey=test&limit=100&offset=0"
+      )
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/xml");
+    expect(body).toContain('total="1"');
+    expect(body).toContain('name="category" value="2040"');
+    expect(body).toContain('name="category" value="2030"');
+    expect(body).toContain('name="category" value="2000"');
+    expect(body).not.toContain('name="category" value="5000"');
+    expect(mediathekMocks.fetchSearchResultsForRssSync).toHaveBeenCalledWith(100, 0);
+  });
+
+  it("returns a TV-category result for a Sonarr sync request", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/newznab/api?t=search&cat=5040,5030,5000&limit=100&offset=0"
+      )
+    );
+    const body = await response.text();
+
+    expect(body).toContain('total="1"');
+    expect(body).toContain('name="category" value="5040"');
+    expect(body).toContain('name="category" value="5030"');
+    expect(body).toContain('name="category" value="5000"');
+    expect(body).not.toContain('name="category" value="2000"');
+  });
+
+  it("provides both parent categories when the client does not request categories", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/newznab/api?t=search&limit=100&offset=0")
+    );
+    const body = await response.text();
+
+    expect(body).toContain('name="category" value="2000"');
+    expect(body).toContain('name="category" value="5000"');
+  });
+
+  it("returns real RSS results unchanged", async () => {
+    const rss = `<?xml version="1.0"?><rss><channel><newznab:response offset="0" total="1"/><item><title>Real result</title></item></channel></rss>`;
+    mediathekMocks.fetchSearchResultsForRssSync.mockResolvedValue(rss);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/newznab/api?t=search&cat=2000")
+    );
+
+    await expect(response.text()).resolves.toBe(rss);
+  });
+
+  it("matches movie categories exactly instead of by substring", async () => {
+    mediathekMocks.fetchSearchResultsByString.mockResolvedValue("<rss>generic search</rss>");
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/newznab/api?t=search&q=Test&cat=12000")
+    );
+
+    await expect(response.text()).resolves.toBe("<rss>generic search</rss>");
+    expect(mediathekMocks.fetchMovieSearchByQuery).not.toHaveBeenCalled();
+    expect(mediathekMocks.fetchSearchResultsByString).toHaveBeenCalledWith("Test", null, 100, 0);
+  });
+
+  it("uses the shared movie validation response for t=movie", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost/api/newznab/api?t=movie&limit=100&offset=0")
+    );
+    const body = await response.text();
+
+    expect(body).toContain('total="1"');
+    expect(body).toContain('name="category" value="2000"');
+    expect(body).toContain('name="category" value="2040"');
+    expect(body).not.toContain('name="category" value="5000"');
+  });
+});

--- a/src/app/api/newznab/route.ts
+++ b/src/app/api/newznab/route.ts
@@ -8,7 +8,13 @@ import {
 } from "@/services/mediathek";
 import { getShowInfoByTvdbId } from "@/services/shows";
 import { getMovieInfoByTmdbId, getMovieInfoByImdbId } from "@/services/tmdb";
-import { serializeRss, getEmptyRssResult } from "@/services/newznab";
+import {
+  serializeRss,
+  getEmptyRssResult,
+  getValidationRss,
+  isMovieCategoryRequest,
+  parseNewznabCategoryIds,
+} from "@/services/newznab";
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -22,6 +28,7 @@ export async function GET(request: NextRequest) {
   const tmdbid = searchParams.get("tmdbid");
   const season = searchParams.get("season");
   const episode = searchParams.get("ep");
+  const categoryIds = parseNewznabCategoryIds(searchParams.get("cat"));
 
   // Handle capabilities request
   if (t === "caps") {
@@ -118,26 +125,8 @@ export async function GET(request: NextRequest) {
         });
       }
 
-      // No search criteria provided - return dummy for Radarr test
-      const dummyMovieRss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
-  <channel>
-    <title>RundfunkArr</title>
-    <description>RundfunkArr API results</description>
-    <newznab:response offset="0" total="1"/>
-    <item>
-      <title>RundfunkArr.Test.2024.GERMAN.1080p.WEB.h264-MEDiATHEK</title>
-      <guid>rundfunkarr-movie-test-item</guid>
-      <pubDate>${new Date().toUTCString()}</pubDate>
-      <category>Movies &gt; HD</category>
-      <enclosure url="http://localhost/test.nzb" length="1000000000" type="application/x-nzb"/>
-      <newznab:attr name="category" value="2000"/>
-      <newznab:attr name="category" value="2040"/>
-      <newznab:attr name="size" value="1000000000"/>
-    </item>
-  </channel>
-</rss>`;
-      return new NextResponse(dummyMovieRss, {
+      // No search criteria provided - return a category-compatible validation item
+      return new NextResponse(getValidationRss(["2000", "2040"]), {
         status: 200,
         headers: { "Content-Type": "application/xml; charset=utf-8" },
       });
@@ -152,14 +141,13 @@ export async function GET(request: NextRequest) {
 
   // Handle TV search requests
   if (t === "tvsearch" || t === "search") {
-    const cat = searchParams.get("cat");
-
     // Check if this is a movie search (by category)
-    const movieCategories = ["2000", "2010", "2020", "2030", "2040", "2045", "2050", "2060"];
-    const isMovieSearch = cat && movieCategories.some((c) => cat.includes(c));
+    const isMovieSearch = isMovieCategoryRequest(categoryIds);
 
     if (isMovieSearch && q) {
-      console.log(`[Newznab] Movie search via t=search detected: q=${q}, cat=${cat}`);
+      console.log(
+        `[Newznab] Movie search via t=search detected: q=${q}, cat=${categoryIds.join(",")}`
+      );
 
       try {
         const searchResults = await fetchMovieSearchByQuery(q, limit, offset);
@@ -217,26 +205,9 @@ export async function GET(request: NextRequest) {
       if (!q && !season && !imdbid && !tvdbid && !tmdbid) {
         const searchResults = await fetchSearchResultsForRssSync(limit, offset);
 
-        // If no results, return a dummy item so Sonarr accepts the indexer
+        // If no results, return an item in the categories requested by the *arr app
         if (searchResults.includes('total="0"')) {
-          const dummyRss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
-  <channel>
-    <title>RundfunkArr</title>
-    <description>RundfunkArr API results</description>
-    <newznab:response offset="0" total="1"/>
-    <item>
-      <title>RundfunkArr Test - Indexer funktioniert</title>
-      <guid>rundfunkarr-test-item</guid>
-      <pubDate>${new Date().toUTCString()}</pubDate>
-      <category>5000</category>
-      <enclosure url="http://localhost/test.nzb" length="1000000" type="application/x-nzb"/>
-      <newznab:attr name="category" value="5000"/>
-      <newznab:attr name="size" value="1000000"/>
-    </item>
-  </channel>
-</rss>`;
-          return new NextResponse(dummyRss, {
+          return new NextResponse(getValidationRss(categoryIds), {
             status: 200,
             headers: { "Content-Type": "application/xml; charset=utf-8" },
           });

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -759,8 +759,10 @@ export default function SetupPage() {
                       4. Klicke &quot;Test&quot; und dann &quot;Save&quot;
                     </p>
                     <p className="text-sm text-muted-foreground">
-                      Prowlarr synct Indexer und Download-Client automatisch zu deinen anderen *arr
-                      Apps.
+                      Prowlarr synchronisiert den Indexer automatisch zu deinen anderen *arr Apps.
+                      Den Download-Client synchronisiert Prowlarr nicht. Richte RundfunkArr dafür
+                      zusätzlich direkt in Sonarr und Radarr ein. Der Download-Client hier ist nur
+                      für manuelle Downloads aus Prowlarr gedacht.
                     </p>
                   </div>
                 </TabsContent>

--- a/src/services/newznab.test.ts
+++ b/src/services/newznab.test.ts
@@ -7,6 +7,9 @@ import {
   generateFakeNzb,
   getCapabilitiesXml,
   generateGenericRssItems,
+  getValidationRss,
+  isMovieCategoryRequest,
+  parseNewznabCategoryIds,
 } from "./newznab";
 import type { NewznabItem, ApiResultItem } from "@/types";
 
@@ -124,6 +127,25 @@ describe("convertItemsToRss", () => {
     expect(xml).toContain("Item0");
     expect(xml).toContain("Item1");
     expect(xml).not.toContain("Item2");
+  });
+});
+
+describe("Newznab validation categories", () => {
+  it("parses unique numeric category IDs", () => {
+    expect(parseNewznabCategoryIds("2040, 2030,2040,invalid")).toEqual(["2040", "2030"]);
+  });
+
+  it("detects movie categories using exact IDs", () => {
+    expect(isMovieCategoryRequest(["2040"])).toBe(true);
+    expect(isMovieCategoryRequest(["12000"])).toBe(false);
+  });
+
+  it("adds the movie parent category to a validation result", () => {
+    const xml = getValidationRss(["2040"], new Date("2026-09-01T00:00:00Z"));
+
+    expect(xml).toContain('name="category" value="2040"');
+    expect(xml).toContain('name="category" value="2000"');
+    expect(xml).not.toContain('name="category" value="5000"');
   });
 });
 

--- a/src/services/newznab.ts
+++ b/src/services/newznab.ts
@@ -16,6 +16,19 @@ const XML_BUILDER = new Builder({
   renderOpts: { pretty: true },
 });
 
+const MOVIE_CATEGORY_IDS = new Set([
+  "2000",
+  "2010",
+  "2020",
+  "2030",
+  "2040",
+  "2045",
+  "2050",
+  "2060",
+]);
+const TV_CATEGORY_IDS = new Set(["5000", "5030", "5040"]);
+const ADVERTISED_CATEGORY_IDS = new Set([...MOVIE_CATEGORY_IDS, ...TV_CATEGORY_IDS]);
+
 export function generateAttributes(
   season: string | null,
   categoryValues: string[],
@@ -117,6 +130,74 @@ export function convertItemsToRss(items: NewznabItem[], limit: number, offset: n
   };
 
   return serializeRss(rss);
+}
+
+export function parseNewznabCategoryIds(categoryParam: string | null): string[] {
+  if (!categoryParam) {
+    return [];
+  }
+
+  return [
+    ...new Set(
+      categoryParam
+        .split(",")
+        .map((category) => category.trim())
+        .filter((category) => /^\d+$/.test(category))
+    ),
+  ];
+}
+
+export function isMovieCategoryRequest(categoryIds: string[]): boolean {
+  return categoryIds.some((categoryId) => MOVIE_CATEGORY_IDS.has(categoryId));
+}
+
+export function getValidationRss(requestedCategoryIds: string[], now: Date = new Date()): string {
+  const categoryIds = requestedCategoryIds.filter((categoryId) =>
+    ADVERTISED_CATEGORY_IDS.has(categoryId)
+  );
+  const hasMovieCategory = categoryIds.some((categoryId) => MOVIE_CATEGORY_IDS.has(categoryId));
+  const hasTvCategory = categoryIds.some((categoryId) => TV_CATEGORY_IDS.has(categoryId));
+
+  if (hasMovieCategory && !categoryIds.includes("2000")) {
+    categoryIds.push("2000");
+  }
+  if (hasTvCategory && !categoryIds.includes("5000")) {
+    categoryIds.push("5000");
+  }
+  if (categoryIds.length === 0) {
+    categoryIds.push("2000", "5000");
+  }
+
+  const movieOnly =
+    categoryIds.some((categoryId) => MOVIE_CATEGORY_IDS.has(categoryId)) &&
+    !categoryIds.some((categoryId) => TV_CATEGORY_IDS.has(categoryId));
+  const title = movieOnly
+    ? "RundfunkArr.Validation.2024.GERMAN.1080p.WEB.h264-TEST"
+    : "RundfunkArr.Validation.S01E01.GERMAN.1080p.WEB.h264-TEST";
+
+  const validationItem: NewznabItem = {
+    title,
+    guid: {
+      isPermaLink: false,
+      value: `rundfunkarr-validation-${movieOnly ? "movie" : "tv"}`,
+    },
+    link: "https://example.invalid/rundfunkarr-validation",
+    comments: "https://example.invalid/rundfunkarr-validation",
+    pubDate: now.toUTCString(),
+    category: movieOnly ? "Movies > HD" : "TV > HD",
+    description: "Synthetic result used to validate RundfunkArr category support.",
+    enclosure: {
+      url: "https://example.invalid/rundfunkarr-validation.nzb",
+      length: 1_000_000,
+      type: "application/x-nzb",
+    },
+    attributes: [
+      ...categoryIds.map((categoryId) => ({ name: "category", value: categoryId })),
+      { name: "size", value: "1000000" },
+    ],
+  };
+
+  return convertItemsToRss([validationItem], 1, 0);
 }
 
 // Title formatting utilities


### PR DESCRIPTION
## Summary

- return category-compatible Newznab validation results for Radarr and Sonarr
- parse category IDs exactly and cover the reported Prowlarr sync request with route tests
- clarify that Prowlarr syncs indexers, while download clients must be configured in each app

## Testing

- `npm test` (78 tests)
- `npm run typecheck`
- `npm run lint` (one pre-existing warning)
- `npm run format:check`
- `npm run build`
- `git diff --check`

Fixes #36

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rundfunkarr/codesmith/rundfunkarr/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790887698&installation_model_id=433282&pr_number=38&repository=rundfunkarr%2Frundfunkarr&return_to=https%3A%2F%2Fgithub.com%2Frundfunkarr%2Frundfunkarr%2Fpull%2F38&signature=ca2feb899c5fde8595779e91d6a2ca16babf91378d806da739090f28691f9207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Newznab category handling for Sonarr and Radarr synchronization.
  - Requests now correctly distinguish movie and TV categories, including parent categories.
  - Empty or incomplete searches return appropriate validation results instead of placeholder content.

- **Documentation**
  - Clarified Prowlarr setup: indexers sync automatically, but download clients must be configured separately in Sonarr and Radarr for downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->